### PR TITLE
fix cutoff for macro call lowering change

### DIFF
--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -47,7 +47,7 @@ Expr(x::EXPR{LITERAL{Tokens.TRIPLE_STRING}}) = x.val
 
 
 # cross compatability for line number insertion in macrocalls
-@static if VERSION <= v"0.7.0-DEV.357"
+@static if VERSION < v"0.7.0-DEV.357"
     Expr(x::EXPR{LITERAL{Tokens.CMD}}) = Expr(:macrocall, Symbol("@cmd"), x.val[2:end-1])
 
     function Expr(x::EXPR{x_Str})


### PR DESCRIPTION
0.7.0-DEV.357 is the merge commit for JuliaLang/julia/9e3318c9840e7a9e387582ba861408cefe5a4f75
so you want strictly less than for old behavior