### PR TITLE
Initial exploration of JuliaParser-style REPL diagnostics

### DIFF
--- a/src/components/operators.jl
+++ b/src/components/operators.jl
@@ -31,7 +31,7 @@ precedence(op::Int) = op < Tokens.end_assignments ?  1 :
                        op < Tokens.end_plus ?        9 :
                        op < Tokens.end_bitshifts ?   10 :
                        op < Tokens.end_times ?       11 :
-                       op < Tfokens.end_rational ?   12 :
+                       op < Tokens.end_rational ?    12 :
                        op < Tokens.end_power ?       13 :
                        op < Tokens.end_decl ?        14 : 
                        op < Tokens.end_where ?       15 : 16

--- a/src/hints.jl
+++ b/src/hints.jl
@@ -11,9 +11,17 @@ mutable struct Diagnostic{C}
 end
 Diagnostic(r::UnitRange) = Diagnostic(r, [], "")
 
-
-
 @enum(ErrorCodes,
+UnexpectedLParen,
+UnexpectedRParen,
+UnexpectedLBrace,
+UnexpectedRBrace,
+UnexpectedLSquare,
+UnexpectedRSquare,
+UnexpectedInputEnd,
+UnexpectedComma,
+UnexpectedOperator,
+UnexpectedIdentifier,
 ParseFailure)
 
 @enum(FormatCodes,
@@ -187,4 +195,58 @@ function format_funcname(ps, id, offset)
     # if !islower(val) #!all(islower(c) || isdigit(c) || c == '!' for c in val)
     #     push!(ps.diagnostics, Diagnostic{Diagnostics.LowerCase}(start_loc + (1:sizeof(val))))
     # end
+end
+
+function error_unexpected(ps, startbyte, tok)
+    if tok.kind == Tokens.ENDMARKER
+        ps.errored = true
+        push!(ps.diagnostics, Diagnostic{Diagnostics.UnexpectedInputEnd}(
+            tok.startbyte:tok.endbyte, [], "Unexpected end of input"
+        ))
+        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, Variable[], "Unexpected end of input")
+    elseif tok.kind == Tokens.COMMA
+        ps.errored = true
+        push!(ps.diagnostics, Diagnostic{Diagnostics.UnexpectedComma}(
+            tok.startbyte:tok.endbyte, [], "Unexpected comma"
+        ))
+        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, Variable[], "Unexpected comma")
+    elseif tok.kind == Tokens.LPAREN
+        ps.errored = true
+        push!(ps.diagnostics, Diagnostic{Diagnostics.UnexpectedLParen}(
+            tok.startbyte:tok.endbyte, [], "Unexpected ("
+        ))
+        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, Variable[], "Unexpected (")
+    elseif tok.kind == Tokens.RPAREN
+        ps.errored = true
+        push!(ps.diagnostics, Diagnostic{Diagnostics.UnexpectedRParen}(
+            tok.startbyte:tok.endbyte, [], "Unexpected )"
+        ))
+        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, Variable[], "Unexpected )")
+    elseif tok.kind == Tokens.LBRACE
+        ps.errored = true
+        push!(ps.diagnostics, Diagnostic{Diagnostics.UnexpectedLBrace}(
+            tok.startbyte:tok.endbyte, [], "Unexpected {"
+        ))
+        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, Variable[], "Unexpected {")
+    elseif tok.kind == Tokens.RBRACE
+        ps.errored = true
+        push!(ps.diagnostics, Diagnostic{Diagnostics.UnexpectedRBrace}(
+            tok.startbyte:tok.endbyte, [], "Unexpected }"
+        ))
+        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, Variable[], "Unexpected }")
+    elseif tok.kind == Tokens.LSQUARE
+        ps.errored = true
+        push!(ps.diagnostics, Diagnostic{Diagnostics.UnexpectedLSquare}(
+            tok.startbyte:tok.endbyte, [], "Unexpected ["
+        ))
+        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, Variable[], "Unexpected [")
+    elseif tok.kind == Tokens.RSQUARE
+        ps.errored = true
+        push!(ps.diagnostics, Diagnostic{Diagnostics.UnexpectedRSquare}(
+            tok.startbyte:tok.endbyte, [], "Unexpected ]"
+        ))
+        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, Variable[], "Unexpected ]")
+    else
+        error("Internal error")
+    end
 end

--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -69,7 +69,7 @@ mutable struct ParseState
     errored::Bool
     current_scope
 end
-function ParseState(str::String)
+function ParseState(str::Union{IO,String})
     ps = ParseState(tokenize(str), false, Token(), Token(), Token(), Token(), Token(), Token(), Token(), Token(), true, true, true, true, [], Closer(), false, Scope{Tokens.TOPLEVEL})
     return next(next(ps))
 end

--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -1,0 +1,56 @@
+using Base.Test
+using CSTParser
+using CSTParser.Diagnostics: Diagnostic, ErrorCodes
+
+using CSTParser.Diagnostics: UnexpectedInputEnd, UnexpectedOperator, UnexpectedIdentifier
+
+function do_diag_test(text)
+    ps = CSTParser.ParseState(text)
+    CSTParser.parse(ps)
+    ps.errored || error("Should have failed")
+    ps.diagnostics
+end
+
+let diags = do_diag_test("abc(d")
+#  none:1:6 ERROR: Unexpected end of input
+#  abc(d
+#       ^
+# JuliaParser.jl did this, which might be more clear
+#  none:1:6 error: Expected ')' or ','
+#  abc(d
+#       ^
+#  none:1:4 note: to match '(' here
+#  abc(d
+#     ^
+    @test length(diags) == 1
+    @test diags[1] isa Diagnostic{UnexpectedInputEnd}
+end
+
+let diags = do_diag_test("a && && b")
+#  none:1:6 ERROR: Unexpected operator
+#  a && && b
+#       ^~~
+    @test diags[1] isa Diagnostic{UnexpectedOperator}
+end
+
+let diags = do_diag_test("print x")
+#  none:1:7 ERROR: Unexpected identifier
+#  print x
+#        ^
+    @test diags[1] isa Diagnostic{UnexpectedIdentifier}
+end
+
+let diags = do_diag_test("a ? b c")
+#  none:1:7 ERROR: Unexpected identifier
+#  a ? b c
+#        ^
+#
+# JuliaParser did this, which might be more clear
+#  none:1:7 error: colon expected in "?" expression
+#  a ? b c
+#        ^
+#  none:1:3 note: "?" was here
+#  a ? b c
+#    ^
+    @test diags[1] isa Diagnostic{UnexpectedIdentifier}
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using CSTParser
 using Base.Test
 
 import CSTParser: parse, remlineinfo!, check_base, span
-# write your own tests here
+
+include("diagnostics.jl")
 include("parser.jl")
 check_base()


### PR DESCRIPTION
Usage:
![screen shot 2017-07-20 at 10 59 33 am](https://user-images.githubusercontent.com/1291671/28424276-3220012a-6d3b-11e7-9399-b38d87fd4b3c.png)


This doesn't port the entire suite of JuliaParser diagnostics, just
a couple to be useful. However, this should get the basic infrastructure
in place upon which we can iterate.