### PR TITLE
Fix misc parsing issues

### DIFF
--- a/src/CSTParser.jl
+++ b/src/CSTParser.jl
@@ -140,7 +140,7 @@ function parse_compound(ps::ParseState, ret)
         ret = parse_operator(ps, ret, op)
     elseif (ret isa EXPR{IDENTIFIER} || (ret isa EXPR{BinarySyntaxOpCall} && ret.args[2] isa EXPR{OPERATOR{DotOp,Tokens.DOT,false}})) && (ps.nt.kind == Tokens.STRING || ps.nt.kind == Tokens.TRIPLE_STRING)
         next(ps)
-        @catcherror ps startbyte arg = parse_string(ps, ret)
+        @catcherror ps startbyte arg = parse_string_or_cmd(ps, ret)
         ret = EXPR{x_Str}(EXPR[ret, arg], ret.span + arg.span, Variable[], "")
     # Suffix on x_str
     elseif ret isa EXPR{x_Str} && ps.nt.kind == Tokens.IDENTIFIER
@@ -150,7 +150,7 @@ function parse_compound(ps::ParseState, ret)
         ret.span += arg.span
     elseif (ret isa EXPR{IDENTIFIER} || (ret isa EXPR{BinarySyntaxOpCall} && ret.args[2] isa EXPR{OPERATOR{DotOp,Tokens.DOT,false}})) && ps.nt.kind == Tokens.CMD
         next(ps)
-        @catcherror ps startbyte arg = parse_string(ps, ret)
+        @catcherror ps startbyte arg = parse_string_or_cmd(ps, ret)
         ret = EXPR{x_Cmd}(EXPR[ret, arg], ret.span + arg.span, Variable[], "")
     elseif ret isa EXPR{x_Cmd} && ps.nt.kind == Tokens.IDENTIFIER
         next(ps)
@@ -282,7 +282,7 @@ function parse_doc(ps::ParseState)
         next(ps)
         doc = INSTANCE(ps)
         next(ps)
-        @catcherror ps startbyte arg = parse_string(ps, doc)
+        @catcherror ps startbyte arg = parse_string_or_cmd(ps, doc)
         doc = EXPR{x_Str}(EXPR[doc, arg], doc.span + arg.span, Variable[], "")
         ret = parse_expression(ps)
         ret = EXPR{MacroCall}(EXPR[GlobalRefDOC, doc, ret], doc.span + ret.span, Variable[], "")

--- a/src/components/genericblocks.jl
+++ b/src/components/genericblocks.jl
@@ -6,7 +6,7 @@ function parse_kw(ps::ParseState, ::Type{Val{Tokens.BEGIN}})
     kw = INSTANCE(ps)
     format_kw(ps)
     arg = EXPR{Block}(EXPR[], 0, Variable[], "")
-    @catcherror ps startbyte arg = @default ps parse_block(ps, arg, start_col)
+    @catcherror ps startbyte arg = @default ps parse_block(ps, arg, start_col, Tokens.Kind[Tokens.END], true)
 
     next(ps)
     return EXPR{Begin}(EXPR[kw; arg; INSTANCE(ps)], ps.nt.startbyte - startbyte, Variable[], "")
@@ -16,11 +16,11 @@ end
 """
     parse_block(ps, ret = EXPR(BLOCK,...))
 
-Parses an array of expressions (stored in ret) until 'end' is the next token. 
-Returns `ps` the token before the closing `end`, the calling function is 
+Parses an array of expressions (stored in ret) until 'end' is the next token.
+Returns `ps` the token before the closing `end`, the calling function is
 assumed to handle the closer.
 """
-function parse_block(ps::ParseState, ret::EXPR{Block}, start_col = 0, closers = Tokens.Kind[Tokens.END, Tokens.CATCH, Tokens.FINALLY])
+function parse_block(ps::ParseState, ret::EXPR{Block}, start_col = 0, closers = Tokens.Kind[Tokens.END, Tokens.CATCH, Tokens.FINALLY], docable = false)
     startbyte = ps.nt.startbyte
     start_line = ps.nt.startpos[1]
     start_col = ps.nt.startpos[2]
@@ -28,7 +28,11 @@ function parse_block(ps::ParseState, ret::EXPR{Block}, start_col = 0, closers = 
     # Parsing
     while !(ps.nt.kind in closers) && !ps.errored
         ps.nt.startpos[1] != start_line && ps.ws.kind == NewLineWS && format_indent(ps, start_col)
-        @catcherror ps startbyte a = @closer ps block parse_expression(ps)
+        if docable
+            @catcherror ps startbyte a = @closer ps block parse_doc(ps)
+        else
+            @catcherror ps startbyte a = @closer ps block parse_expression(ps)
+        end
         push!(ret.args, a)
     end
     ret.span = ps.nt.startbyte - startbyte

--- a/src/components/strings.jl
+++ b/src/components/strings.jl
@@ -1,126 +1,143 @@
-"""
-    parse_string(ps)
+function longest_common_prefix(prefixa, prefixb)
+    maxplength = min(sizeof(prefixa), sizeof(prefixb))
+    maxplength == 0 && return ""
+    idx = findfirst(i->(prefixa[i] != prefixb[i]),1:maxplength)
+    idx = idx == 0 ? maxplength : idx - 1
+    prefixa[1:idx]
+end
 
-When trying to make an `INSTANCE` from a string token we must check for 
+function skip_to_nl(str, idxend)
+    while (idxend < length(str)) && str[idxend] != '\n'
+        idxend = nextind(str, idxend)
+    end
+    idxend
+end
+
+tostr(buf::IOBuffer) = unescape_string(String(take!(buf)))
+
+"""
+parse_string_or_cmd(ps)
+
+When trying to make an `INSTANCE` from a string token we must check for
 interpolating operators.
 """
-function parse_string(ps::ParseState, prefixed = false)
+function parse_string_or_cmd(ps::ParseState, prefixed = false)
     startbyte = ps.t.startbyte
-    
+
     span = ps.nt.startbyte - ps.t.startbyte
-    istrip = ps.t.kind == Tokens.TRIPLE_STRING
-    
+    istrip = (ps.t.kind == Tokens.TRIPLE_STRING) || (ps.t.kind == Tokens.TRIPLE_CMD)
+    iscmd = ps.t.kind == Tokens.CMD || ps.t.kind == Tokens.TRIPLE_CMD
+
     if ps.errored
         return EXPR{ERROR}([], 0, [], ps.t.val)
     end
 
-    if istrip
-        lit = unindent_triple_string(ps)
-    else
-        lit = EXPR{LITERAL{ps.t.kind}}(Expr[], span, Variable[], ps.t.val[2:end - 1])   
+    lcp = nothing
+    exprs_to_adjust = EXPR[]
+    function adjust_lcp(expr, last = false)
+        push!(exprs_to_adjust, expr)
+        str = expr.val
+        isempty(str) || (lcp != nothing && isempty(lcp)) && return
+        (last && str[end] == '\n') && return (lcp = "")
+        idxstart, idxend = 2, 1
+        while idxend < sizeof(str) && (lcp == nothing || !isempty(lcp))
+            idxend = skip_to_nl(str, idxend)
+            idxstart = nextind(str, idxend)
+            while idxend < sizeof(str)
+                c = str[nextind(str, idxend)]
+                if c == ' ' || c == '\t'
+                    idxend += 1
+                elseif c == '\n'
+                    # All whitespace lines in the middle are ignored
+                    idxend += 1
+                    idxstart = idxend+1
+                else
+                    prefix = str[idxstart:idxend]
+                    lcp = lcp === nothing ? prefix : longest_common_prefix(lcp, prefix)
+                    break
+                end
+            end
+        end
+        if idxstart != idxend + 1
+            prefix = str[idxstart:idxend]
+            lcp = lcp === nothing ? prefix : longest_common_prefix(lcp, prefix)
+        end
     end
 
     # there are interpolations in the string
-    if prefixed != false
-        if prefixed.val == :r
-            lit.val = replace(lit.val, "\\\"", "\"")
+    if prefixed != false || iscmd
+        val = istrip ? ps.t.val[4:end-3] : ps.t.val[2:end-1]
+        expr = EXPR{LITERAL{ps.t.kind}}(Expr[], span, Variable[],
+            iscmd ? replace(val, "\\`", "`") :
+                    replace(val, "\\\"", "\""))
+        if istrip
+            adjust_lcp(expr)
+            ret = EXPR{StringH}(EXPR[expr], span, Variable[], "")
+        else
+            return expr
         end
-        return lit
-    elseif ismatch(r"(?<!\\)\$", lit.val) # _has_interp(lit.val)
-        io = IOBuffer(lit.val)
-        ret = EXPR{StringH}(EXPR[], lit.span, Variable[], "")
-        lc = ' '
-        while !eof(io)
-            io2 = IOBuffer()
-            # conseq_slash = 0
-            while !eof(io)
-                c = read(io, Char)
-                write(io2, c)
-                if c == '$' && lc != '\\' # && iseven(conseq_slash) 
-                    break
-                end
-                lc = c
-                # if c == '\\'
-                #     conseq_slash +=1
-                # else
-                #     conseq_slash = 0
-                # end
+    else
+        ret = EXPR{StringH}(EXPR[], span, Variable[], "")
+        input = IOBuffer(ps.t.val)
+        seek(input, istrip ? 3 : 1)
+        b = IOBuffer()
+        while true
+            if eof(input)
+                lspan = position(b)
+                str = tostr(b)[1:end-(istrip?3:1)]
+                ex = EXPR{LITERAL{Tokens.STRING}}(EXPR[], lspan, Variable[], str)
+                (isempty(ret.args) || !isempty(str)) && (push!(ret.args, ex); istrip && adjust_lcp(ex, true))
+                break
             end
-            str1 = String(take!(io2))
-
-            if length(str1) > 0 && last(str1) === '$' && (length(str1) == 1 || str1[chr2ind(str1, length(str1) - 1)] != '\\')
-                lit2 = EXPR{LITERAL{Tokens.STRING}}(EXPR[], endof(str1) - 1, Variable[], unescape_string(str1[1:end - 1]))
-                if !isempty(lit2.val)
-                    push!(ret.args, lit2)
+            c = read(input, Char)
+            if c == '\\'
+                write(b, c)
+                write(b, read(input, Char))
+            elseif c == '$'
+                lspan = position(b)
+                str = tostr(b)
+                if !isempty(str)
+                    ex = EXPR{LITERAL{Tokens.STRING}}(EXPR[], lspan, Variable[], str)
+                    push!(ret.args, ex); istrip && adjust_lcp(ex)
                 end
-                if peekchar(io) == '('
-                    ps1 = ParseState(lit.val[io.ptr + 1:end])
-                    leading_ws_span = 0
-                    if ps1.nt.kind == Tokens.WHITESPACE
-                        next(ps1)
-                        leading_ws_span = ps1.nt.startbyte - ps1.t.startbyte
-                    end
+                if peekchar(input) == '('
+                    skip(input, 1)
+                    ps1 = ParseState(input)
                     @catcherror ps startbyte interp = @closer ps1 paren parse_expression(ps1)
                     push!(ret.args, interp)
-                    skip(io, interp.span + 2 + leading_ws_span)
+                    # Comparse to flisp/JuliaParser, we have an extra lookahead token,
+                    # so we need to back up one here
+                    seek(input, ps1.nt.startbyte+1)
                 else
-                    ps1 = ParseState(lit.val[io.ptr:end])
+                    pos = position(input)
+                    ps1 = ParseState(input)
                     next(ps1)
-                    interp = INSTANCE(ps1)
-                    push!(ret.args, interp)
-                    
-                    skip(io, interp.span - length(ps1.ws.val))
+                    t = INSTANCE(ps1)
+                    push!(ret.args, t)
+                    seek(input, pos+t.span-length(ps1.ws.val))
                 end
             else
-                push!(ret.args, EXPR{LITERAL{Tokens.STRING}}(EXPR[], sizeof(str1) - 1, Variable[], unescape_string(str1)))
+                write(b, c)
             end
         end
-        return ret
-    else
-        lit.val = unescape_string(lit.val)
-        return lit
     end
+
+    single_string_T = Union{EXPR{LITERAL{Tokens.STRING}},EXPR{LITERAL{ps.t.kind}}}
+    if istrip
+        if lcp != nothing && !isempty(lcp)
+            for expr in exprs_to_adjust
+                expr.val = replace(expr.val, "\n$lcp", "\n")
+            end
+        end
+        # Drop leading newline
+        if ret.args[1] isa single_string_T &&
+                !isempty(ret.args[1].val) && ret.args[1].val[1] == '\n'
+            ret.args[1].val = ret.args[1].val[2:end]
+        end
+    end
+
+    ret = (length(ret.args) == 1 && ret.args[1] isa single_string_T) ? ret.args[1] : ret
     ret.span = span
+
     return ret
-end
-
-function _has_interp(str)
-    i = 1
-    conseq_slash = 0
-    while i < endof(str)
-        if str[i] == '$' && iseven(conseq_slash)
-            return true
-        elseif str[i] == '\\'
-            conseq_slash += 1
-        else 
-            conseq_slash = 0
-        end
-        i = nextind(str, i)
-    end
-    return false
-end
-
-function unindent_triple_string(ps::ParseState)
-    indent = -1
-    leading_newline = startswith(ps.t.val, "\"\"\"\n")
-    val = leading_newline ? ps.t.val[5:end - 3] : ps.t.val[4:end - 3]
-    io = IOBuffer(val)
-    while !eof(io)
-        c = readuntil(io, '\n')
-        eof(io) && break
-        peekchar(io) == '\n' && skip(io, 1)
-        cnt = 0
-        while iswhitespace(peekchar(io)) && peekchar(io) != '\n'
-            read(io, Char)
-            cnt += 1
-        end
-        indent = indent == -1 ? cnt : min(indent, cnt)
-    end
-    if indent > -1
-        val = Base.unindent(val, indent)
-        # if !leading_newline
-        #     val = string(" "^indent, val)
-        # end
-    end
-    lit = EXPR{LITERAL{ps.t.kind}}(EXPR[], ps.nt.startbyte - ps.t.startbyte - ps.ndot, Variable[], val)
 end

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -100,12 +100,10 @@ Expr(x::EXPR{LITERAL{Tokens.MACRO}}) = Symbol(x.val)
 Expr(x::EXPR{LITERAL{Tokens.STRING}}) = x.val
 Expr(x::EXPR{LITERAL{Tokens.TRIPLE_STRING}}) = x.val
 
-
-
 # cross compatability for line number insertion in macrocalls
 @static if VERSION < v"0.7.0-DEV.357"
-    Expr(x::EXPR{LITERAL{Tokens.CMD}}) = Expr(:macrocall, Symbol("@cmd"), x.val[2:end-1])
-    Expr(x::EXPR{LITERAL{Tokens.TRIPLE_CMD}}) = Expr(:macrocall, Symbol("@cmd"), x.val[2:end-1])    
+    Expr(x::EXPR{LITERAL{Tokens.CMD}}) = Expr(:macrocall, Symbol("@cmd"), x.val)
+    Expr(x::EXPR{LITERAL{Tokens.TRIPLE_CMD}}) = Expr(:macrocall, Symbol("@cmd"), x.val)
 
     function Expr(x::EXPR{x_Str})
         if x.args[1] isa EXPR{BinarySyntaxOpCall}
@@ -154,8 +152,8 @@ Expr(x::EXPR{LITERAL{Tokens.TRIPLE_STRING}}) = x.val
         x
     end
 else
-    Expr(x::EXPR{LITERAL{Tokens.CMD}}) = Expr(:macrocall, Symbol("@cmd"), nothing, x.val[2:end-1])
-    Expr(x::EXPR{LITERAL{Tokens.TRIPLE_CMD}}) = Expr(:macrocall, Symbol("@cmd"), nothing, x.val[2:end-1])
+    Expr(x::EXPR{LITERAL{Tokens.CMD}}) = Expr(:macrocall, Symbol("@cmd"), nothing, x.val)
+    Expr(x::EXPR{LITERAL{Tokens.TRIPLE_CMD}}) = Expr(:macrocall, Symbol("@cmd"), nothing, x.val)
 
     function Expr(x::EXPR{x_Str})
         if x.args[1] isa EXPR{BinarySyntaxOpCall}

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -22,8 +22,9 @@ abstract type ERROR end
 
 function LITERAL(ps::ParseState)
     span = ps.nt.startbyte - ps.t.startbyte
-    if ps.t.kind == Tokens.STRING || ps.t.kind == Tokens.TRIPLE_STRING
-        return parse_string(ps)
+    if ps.t.kind == Tokens.STRING || ps.t.kind == Tokens.TRIPLE_STRING ||
+       ps.t.kind == Tokens.CMD || ps.t.kind == Tokens.TRIPLE_CMD
+        return parse_string_or_cmd(ps)
     else
         EXPR{LITERAL{ps.t.kind}}(EXPR[], span, Variable[], ps.t.val)
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -3,7 +3,7 @@ function closer(ps::ParseState)
     (ps.closer.semicolon && ps.ws.kind == SemiColonWS) ||
     (isoperator(ps.nt) && precedence(ps.nt) <= ps.closer.precedence) ||
     (ps.nt.kind == Tokens.WHERE && ps.closer.precedence == 5) ||
-    (ps.closer.inwhere && ps.nt.kind == Tokens.WHERE) || 
+    (ps.closer.inwhere && ps.nt.kind == Tokens.WHERE) ||
     (ps.nt.kind == Tokens.LPAREN && ps.closer.precedence > 15) ||
     (ps.nt.kind == Tokens.LBRACE && ps.closer.precedence > 15) ||
     (ps.nt.kind == Tokens.LSQUARE && ps.closer.precedence > 15) ||
@@ -12,7 +12,7 @@ function closer(ps::ParseState)
     (ps.closer.precedence > 15 && ps.t.kind == Tokens.RSQUARE && ps.nt.kind == Tokens.IDENTIFIER) ||
     (ps.nt.kind == Tokens.COMMA && ps.closer.precedence > 0) ||
     ps.nt.kind == Tokens.ENDMARKER ||
-    (ps.closer.comma && iscomma(ps.nt)) || 
+    (ps.closer.comma && iscomma(ps.nt)) ||
     (ps.closer.tuple && (iscomma(ps.nt) || isassignment(ps.nt))) ||
     (ps.nt.kind == Tokens.FOR && ps.closer.precedence > -1) ||
     (ps.closer.paren && ps.nt.kind == Tokens.RPAREN) ||
@@ -24,10 +24,10 @@ function closer(ps::ParseState)
     (ps.closer.trycatch && (ps.nt.kind == Tokens.CATCH || ps.nt.kind == Tokens.FINALLY || ps.nt.kind == Tokens.END)) ||
     (ps.closer.range && ps.nt.kind == Tokens.FOR) ||
     (ps.closer.ws && !isemptyws(ps.ws) &&
-        !(ps.nt.kind == Tokens.COMMA) && 
-        !(ps.t.kind == Tokens.COMMA) && 
+        !(ps.nt.kind == Tokens.COMMA) &&
+        !(ps.t.kind == Tokens.COMMA) &&
         !(!ps.closer.inmacro && ps.nt.kind == Tokens.FOR) &&
-        !(ps.nt.kind == Tokens.DO) && 
+        !(ps.nt.kind == Tokens.DO) &&
         # !((isbinaryop(ps.nt.kind) && (!isemptyws(ps.nws) || !isunaryop(ps.nt))) || (!ps.closer.wsop && isbinaryop(ps.nt.kind)))) ||
         !((isbinaryop(ps.nt) && !isemptyws(ps.nws)) ||
         (isbinaryop(ps.nt) && !isunaryop(ps.nt)) ||
@@ -38,7 +38,7 @@ function closer(ps::ParseState)
 end
 
 """
-    @closer ps rule body 
+    @closer ps rule body
 
 Continues parsing closing on `rule`.
 """
@@ -53,7 +53,7 @@ macro closer(ps, opt, body)
 end
 
 """
-    @nocloser ps rule body 
+    @nocloser ps rule body
 
 Continues parsing not closing on `rule`.
 """
@@ -68,7 +68,7 @@ macro nocloser(ps, opt, body)
 end
 
 """
-    @precedence ps prec body 
+    @precedence ps prec body
 
 Continues parsing binary operators until it hits a more loosely binding
 operator (with precdence lower than `prec`).
@@ -122,7 +122,7 @@ macro default(ps, body)
         $(esc(ps)).closer.precedence = -1
 
         out = $(esc(body))
-        
+
         $(esc(ps)).closer.newline = tmp1
         $(esc(ps)).closer.semicolon = tmp2
         $(esc(ps)).closer.inmacro = tmp3
@@ -143,7 +143,7 @@ macro default(ps, body)
 end
 
 """
-    @scope ps scope body 
+    @scope ps scope body
 
 Continues parsing tracking declared variables.
 """
@@ -173,7 +173,7 @@ macro noscope(ps, body)
 end
 
 """
-    @catcherror ps body 
+    @catcherror ps body
 
 Checks for `ps.errored`.
 """
@@ -198,19 +198,19 @@ iskw(t::Token) = Tokens.iskeyword(t.kind)
 
 isinstance(t::Token) = isidentifier(t) ||
                        isliteral(t) ||
-                       isbool(t) || 
+                       isbool(t) ||
                        iskw(t)
 
 
 ispunctuation(t::Token) = t.kind == Tokens.COMMA ||
                           t.kind == Tokens.END ||
                           Tokens.LSQUARE ≤ t.kind ≤ Tokens.RPAREN
-                          
+
 isstring(x) = false
 isstring(x::EXPR{T}) where T <: Union{StringH, LITERAL{Tokens.STRING},LITERAL{Tokens.TRIPLE_STRING}} = true
 
 isajuxtaposition(ps::ParseState, ret) = ((ret isa EXPR{LITERAL{Tokens.INTEGER}} || ret isa EXPR{LITERAL{Tokens.FLOAT}}) && (ps.nt.kind == Tokens.IDENTIFIER || ps.nt.kind == Tokens.LPAREN || ps.nt.kind == Tokens.CMD || ps.nt.kind == Tokens.STRING || ps.nt.kind == Tokens.TRIPLE_STRING)) || (
-        (ret isa EXPR{UnarySyntaxOpCall} && ret.args[2] isa EXPR{OPERATOR{16,Tokens.PRIME,false}} && ps.nt.kind == Tokens.IDENTIFIER) || 
+        (ret isa EXPR{UnarySyntaxOpCall} && ret.args[2] isa EXPR{OPERATOR{16,Tokens.PRIME,false}} && ps.nt.kind == Tokens.IDENTIFIER) ||
         ((ps.t.kind == Tokens.RPAREN || ps.t.kind == Tokens.RSQUARE) && (ps.nt.kind == Tokens.IDENTIFIER || ps.nt.kind == Tokens.CMD)) ||
         ((ps.t.kind == Tokens.STRING || ps.t.kind == Tokens.TRIPLE_STRING) && (ps.nt.kind == Tokens.STRING || ps.nt.kind == Tokens.TRIPLE_STRING))) ||
         (isstring(ret) && ps.nt.kind == Tokens.IDENTIFIER && ps.ws.kind == EmptyWS)
@@ -355,6 +355,7 @@ function check_base(dir = dirname(Base.find_source_file("base.jl")), display = f
                             push!(x1.args, flisp_parse(io))
                         end
                     catch er
+                        isa(er, InterruptException) && rethrow(er)
                         if display
                             Base.showerror(STDOUT, er, catch_backtrace())
                             println()
@@ -389,11 +390,12 @@ function check_base(dir = dirname(Base.find_source_file("base.jl")), display = f
                             print_with_color(:light_red, string("    ", c0), bold = true)
                             println()
                             print_with_color(:light_green, string("    ", c1), bold = true)
-                            println()                            
+                            println()
                         end
                         push!(ret, (file, :noteq))
                     end
                 catch er
+                    isa(er, InterruptException) && rethrow(er)
                     if display
                         Base.showerror(STDOUT, er, catch_backtrace())
                         println()
@@ -492,7 +494,7 @@ function check_reformat()
         for i = 1:length(x) - 1
             y = x[i]
             sstr = str[cnt + (1:y.span)]
-            
+
             y1 = parse(sstr)
             @assert Expr(y) == Expr(y1)
             cnt += y.span
@@ -506,7 +508,7 @@ is_func_call(x) = false
 is_func_call(x::EXPR) = false
 is_func_call(x::EXPR{Call}) = true
 is_func_call(x::EXPR{UnaryOpCall}) = true
-function is_func_call(x::EXPR{BinarySyntaxOpCall}) 
+function is_func_call(x::EXPR{BinarySyntaxOpCall})
     if length(x.args) > 1 && (x.args[2] isa EXPR{OPERATOR{WhereOp,Tokens.WHERE,false}} || x.args[2] isa EXPR{OPERATOR{DeclarationOp,Tokens.DECLARATION,false}})
         return is_func_call(x.args[1])
     else

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -14,12 +14,11 @@ randop() = rand(["-->", "→",
                  "::",
                  ".", "->"])
 
-
 function test_expr(str)
     x, ps = CSTParser.parse(ParseState(str))
 
     x0 = Expr(x)
-    x1 = remlineinfo!(Base.parse(str))
+    x1 = remlineinfo!(flisp_parse(str))
     !ps.errored && x0 == x1# && isempty(span(x))
 end
 

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -519,9 +519,9 @@ end
     "\"\"\"\n$ws%rv = atomicrmw \$rmw \$lt* %0, \$lt %1 acq_rel\n$(ws)ret \$lt %rv\n$ws\"\"\"" |> test_expr
     ws1 = "        "
     ws2 = "    "
-    "\"\"\"\n$(ws1)a\n$(ws1)b\n$(ws2)c\n$(ws2)d\n$(ws2)\"\"\"" |> text_expr
-    "\"\"\"\n$(ws1)a\n\n$(ws1)b\n\n$(ws2)c\n\n$(ws2)d\n\n$(ws2)\"\"\"" |> text_expr
-    "\"\"\"\n$(ws1)α\n$(ws1)β\n$(ws2)γ\n$(ws2)δ\n$(ws2)\"\"\"" |> text_expr
+    "\"\"\"\n$(ws1)a\n$(ws1)b\n$(ws2)c\n$(ws2)d\n$(ws2)\"\"\"" |> test_expr
+    "\"\"\"\n$(ws1)a\n\n$(ws1)b\n\n$(ws2)c\n\n$(ws2)d\n\n$(ws2)\"\"\"" |> test_expr
+    "\"\"\"\n$(ws1)α\n$(ws1)β\n$(ws2)γ\n$(ws2)δ\n$(ws2)\"\"\"" |> test_expr
 end
 
 @testset "No longer broken things" begin
@@ -649,6 +649,7 @@ end
     @test """
         "\\\\\$ch"
         """ |> test_expr
+    @test "begin\n\"\"\"Float\$(bit)\"\"\"\n\$(Symbol(\"Float\",bit))\nend" |> test_expr
 end
 
 @testset "Broken things" begin

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -650,12 +650,12 @@ end
         "\\\\\$ch"
         """ |> test_expr
     @test "begin\n\"\"\"Float\$(bit)\"\"\"\n\$(Symbol(\"Float\",bit))\nend" |> test_expr
+    @test "µs" |> test_expr # normalize unicode
 end
 
 @testset "Broken things" begin
     @test_broken "\$(a) * -\$(b)" |> test_expr
     @test_broken "function(f, args...; kw...) end" |> test_expr
-    @test_broken "µs" |> test_expr # normalize unicode
     @test_broken """let f = ((; a = 1, b = 2) -> ()),
                 m = first(methods(f))
                 @test DSE.keywords(f, m) == [:a, :b]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,8 @@
 using CSTParser
 using Base.Test
 
-import CSTParser: parse, remlineinfo!, check_base, span
+import CSTParser: parse, remlineinfo!, span, flisp_parse
 
 include("diagnostics.jl")
 include("parser.jl")
-check_base()
+CSTParser.check_base()


### PR DESCRIPTION
The first commit fixes the experience when loading FancyDiagnostic. Rather than falling back to the flisp parser, for certain corner cases, do everything in this package (with FancyDiagnostics, Base.parse calls CSTParser.parse). The next two commits fix various issues that show up in the base comparison test, which now passes. I also went ahead and stripped trailing whitespace in the files that I touched.