### PR TITLE
Drop pre-0.6 versions from REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.6.0-pre.beta
+julia 0.6.0
 Tokenize 0.1.10
 AbstractTrees


### PR DESCRIPTION
After this, CSTParser could use a visit from femtocleaner.