### PR TITLE
Add more precise diagnostics for new error paths

### DIFF
--- a/src/components/controlflow.jl
+++ b/src/components/controlflow.jl
@@ -26,11 +26,12 @@ function parse_if(ps::ParseState, nested = false)
     # Parsing
     kw = KEYWORD(ps)
     if ps.ws.kind == NewLineWS || ps.ws.kind == SemiColonWS
-        return EXPR{ERROR}(Any[])
+        return make_error(ps, 1 + (ps.t.endbyte:ps.t.endbyte), Diagnostics.MissingConditional,
+            "missing conditional in `$(lowercase(string(ps.t.kind)))`")
     end
     @catcherror ps cond = @default ps @closer ps block @closer ps ws parse_expression(ps)
 
-    
+
     ifblockargs = Any[]
     @catcherror ps @default ps @closer ps ifelse parse_block(ps, ifblockargs, (Tokens.END, Tokens.ELSE, Tokens.ELSEIF))
 
@@ -71,7 +72,7 @@ function parse_let(ps::ParseState)
             push!(args, PUNCTUATION(next(ps)))
         end
     end
-    
+
     blockargs = Any[]
     @catcherror ps @default ps parse_block(ps, blockargs)
 

--- a/src/components/functions.jl
+++ b/src/components/functions.jl
@@ -105,7 +105,9 @@ function parse_call(ps::ParseState, ret::ANY)
     end
     args = Any[ret, PUNCTUATION(next(ps))]
     @default ps @closer ps paren parse_comma_sep(ps, args)
-    push!(args, PUNCTUATION(next(ps)))
+    rparen = PUNCTUATION(next(ps))
+    rparen.kind == Tokens.RPAREN || return error_unexpected(ps, ps.t)
+    push!(args, rparen)
     return EXPR{Call}(args)
 end
 

--- a/src/hints.jl
+++ b/src/hints.jl
@@ -27,6 +27,8 @@ UnexpectedCharEnd,
 UnexpectedComma,
 UnexpectedOperator,
 UnexpectedIdentifier,
+MissingConditional,
+InvalidIter,
 ParseFailure)
 
 @enum(LintCodes,

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,8 @@
+if VERSION < v"0.7.0-DEV.1053"
+    read(io, ::Type{String}) = readstring(io)
+    read(io, ::Type{Char}) = Base.read(io, Char)
+end
+
 function closer(ps::ParseState)
     (ps.closer.newline && ps.ws.kind == NewLineWS && ps.t.kind != Tokens.COMMA) ||
     (ps.closer.semicolon && ps.ws.kind == SemiColonWS) ||

--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -3,7 +3,7 @@ using CSTParser
 using CSTParser.Diagnostics: Diagnostic, ErrorCodes
 
 using CSTParser.Diagnostics: UnexpectedInputEnd, UnexpectedOperator, UnexpectedIdentifier, UnexpectedStringEnd,
-    UnexpectedCommentEnd, UnexpectedBlockEnd, UnexpectedCmdEnd, UnexpectedCharEnd
+    UnexpectedCommentEnd, UnexpectedBlockEnd, UnexpectedCmdEnd, UnexpectedCharEnd, InvalidIter, MissingConditional
 
 
 function do_diag_test(text)
@@ -55,6 +55,20 @@ let diags = do_diag_test("a ? b c")
 #  a ? b c
 #    ^
     @test diags[1] isa Diagnostic{UnexpectedIdentifier}
+end
+
+let diags = do_diag_test("[x for (x ? true : false)]")
+#  REPL[2]:1:8 ERROR: invalid iteration specification
+#  [x for (x ? true : false)]
+#         ^~~~~~~~~~~~~~~~~~
+    @test diags[1] isa Diagnostic{InvalidIter}
+end
+
+let diags = do_diag_test("if\n\true\nend")
+#  REPL[3]:1:3 ERROR: missing conditional in `if`
+#  if
+#    ^
+    @test diags[1] isa Diagnostic{MissingConditional}
 end
 
 function test_eof_diag(text, code)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,5 +4,5 @@ using Base.Test
 import CSTParser: parse, remlineinfo!, span, flisp_parse
 
 include("parser.jl")
-# include("diagnostics.jl")
+include("diagnostics.jl")
 CSTParser.check_base()


### PR DESCRIPTION
```julia
julia> using FancyDiagnostics

julia> [x for (x ? true : false)]
REPL[2]:1:8 ERROR: invalid iteration specification
[x for (x ? true : false)]
       ^~~~~~~~~~~~~~~~~~

julia> if
       true
REPL[3]:1:3 ERROR: missing conditional in `if`
if
  ^
```