### PR TITLE
Proof of Concept: use RawToken

### DIFF
--- a/src/CSTParser.jl
+++ b/src/CSTParser.jl
@@ -7,7 +7,7 @@ using AbstractTrees
 using Tokenize
 import Base: next, start, done, length, first, last, endof, getindex, setindex!
 import Tokenize.Tokens
-import Tokenize.Tokens: Token, iskeyword, isliteral, isoperator, untokenize
+import Tokenize.Tokens: RawToken, AbstractToken, iskeyword, isliteral, isoperator, untokenize
 import Tokenize.Lexers: Lexer, peekchar, iswhitespace
 
 export ParseState, parse_expression
@@ -202,14 +202,14 @@ function parse_compound(ps::ParseState, ret)
     # Suffix on x_str
     elseif ret isa EXPR{x_Str} && ps.nt.kind == Tokens.IDENTIFIER
         arg = IDENTIFIER(next(ps))
-        push!(ret, LITERAL(arg.fullspan, arg.span, ps.t.val, Tokens.STRING))
+        push!(ret, LITERAL(arg.fullspan, arg.span, val(ps.t, ps), Tokens.STRING))
     elseif (ret isa IDENTIFIER || (ret isa BinarySyntaxOpCall && is_dot(ret.op))) && ps.nt.kind == Tokens.CMD
         next(ps)
         @catcherror ps arg = parse_string_or_cmd(ps, ret)
         ret = EXPR{x_Cmd}(Any[ret, arg])
     elseif ret isa EXPR{x_Cmd} && ps.nt.kind == Tokens.IDENTIFIER
         arg = IDENTIFIER(next(ps))
-        push!(ret, LITERAL(arg.fullspan, 1:span(arg), ps.t.val, Tokens.STRING))
+        push!(ret, LITERAL(arg.fullspan, 1:span(arg), val(ps.t, ps), Tokens.STRING))
     elseif ret isa UnarySyntaxOpCall && is_prime(ret.arg2)
         # prime operator followed by an identifier has an implicit multiplication
         @catcherror ps nextarg = @precedence ps 11 parse_expression(ps)
@@ -292,7 +292,7 @@ function parse_doc(ps::ParseState)
 
         ret = parse_expression(ps)
         ret = EXPR{MacroCall}(Any[GlobalRefDOC, doc, ret])
-    elseif ps.nt.kind == Tokens.IDENTIFIER && ps.nt.val == "doc" && (ps.nnt.kind == Tokens.STRING || ps.nnt.kind == Tokens.TRIPLE_STRING)
+    elseif ps.nt.kind == Tokens.IDENTIFIER && val(ps.nt, ps) == "doc" && (ps.nnt.kind == Tokens.STRING || ps.nnt.kind == Tokens.TRIPLE_STRING)
         doc = IDENTIFIER(next(ps))
         next(ps)
         @catcherror ps arg = parse_string_or_cmd(ps, doc)
@@ -378,7 +378,7 @@ end
 
 
 
-ischainable(t::Token) = t.kind == Tokens.PLUS || t.kind == Tokens.STAR || t.kind == Tokens.APPROX
+ischainable(t::AbstractToken) = t.kind == Tokens.PLUS || t.kind == Tokens.STAR || t.kind == Tokens.APPROX
 
 include("_precompile.jl")
 _precompile_()

--- a/src/components/modules.jl
+++ b/src/components/modules.jl
@@ -1,5 +1,6 @@
 function parse_module(ps::ParseState)
     kw = KEYWORD(ps)
+    @assert kw.kind == Tokens.MODULE || kw.kind == Tokens.BAREMODULE # work around julia issue #23766
     if ps.nt.kind == Tokens.IDENTIFIER
         arg = IDENTIFIER(next(ps))
     else

--- a/src/components/operators.jl
+++ b/src/components/operators.jl
@@ -37,16 +37,16 @@ precedence(kind::Tokens.Kind) = kind == Tokens.DDDOT ? DddotOp :
                        kind == Tokens.PRIME ?             16 : 20
 
 precedence(x) = 0
-precedence(x::Token) = precedence(x.kind)
+precedence(x::AbstractToken) = precedence(x.kind)
 precedence(x::OPERATOR) = precedence(x.kind)
 
 
 isoperator(kind) = Tokens.begin_ops < kind < Tokens.end_ops
-isoperator(t::Token) = isoperator(t.kind)
+isoperator(t::AbstractToken) = isoperator(t.kind)
 
 
 isunaryop(op::OPERATOR) = isunaryop(op.kind)
-isunaryop(t::Token) = isunaryop(t.kind)
+isunaryop(t::AbstractToken) = isunaryop(t.kind)
 
 isunaryop(kind) = kind == Tokens.ISSUBTYPE ||
                   kind == Tokens.ISSUPERTYPE ||
@@ -64,7 +64,7 @@ isunaryop(kind) = kind == Tokens.ISSUBTYPE ||
                   kind == Tokens.COLON
 
 
-isunaryandbinaryop(t::Token) = isunaryandbinaryop(t.kind)
+isunaryandbinaryop(t::AbstractToken) = isunaryandbinaryop(t.kind)
 isunaryandbinaryop(kind) = kind == Tokens.PLUS ||
                            kind == Tokens.MINUS ||
                            kind == Tokens.EX_OR ||
@@ -76,7 +76,7 @@ isunaryandbinaryop(kind) = kind == Tokens.PLUS ||
                            kind == Tokens.COLON
 
 isbinaryop(op::OPERATOR) = isbinaryop(op.kind)
-isbinaryop(t::Token) = isbinaryop(t.kind)
+isbinaryop(t::AbstractToken) = isbinaryop(t.kind)
 isbinaryop(kind) = isoperator(kind) &&
                     !(kind == Tokens.SQUARE_ROOT ||
                     kind == Tokens.CUBE_ROOT ||
@@ -84,9 +84,9 @@ isbinaryop(kind) = isoperator(kind) &&
                     kind == Tokens.NOT ||
                     kind == Tokens.NOT_SIGN)
 
-isassignment(t::Token) = Tokens.begin_assignments < t.kind < Tokens.end_assignments
+isassignment(t::AbstractToken) = Tokens.begin_assignments < t.kind < Tokens.end_assignments
 
-function non_dotted_op(t::Token)
+function non_dotted_op(t::AbstractToken)
     k = t.kind
     return (k == Tokens.COLON_EQ ||
             k == Tokens.PAIR_ARROW ||
@@ -153,7 +153,7 @@ function parse_unary(ps::ParseState, op)
         return parse_unary_colon(ps, op)
     elseif (is_plus(op) || is_minus(op)) && (ps.nt.kind ==  Tokens.INTEGER || ps.nt.kind == Tokens.FLOAT) && isemptyws(ps.ws)
         arg = LITERAL(next(ps))
-        return LITERAL(op.fullspan + arg.fullspan, first(arg.span):(last(arg.span) + length(op.span)), string(is_plus(op) ? "+" : "-" , ps.t.val), ps.t.kind)
+        return LITERAL(op.fullspan + arg.fullspan, first(arg.span):(last(arg.span) + length(op.span)), string(is_plus(op) ? "+" : "-" , val(ps.t, ps)), ps.t.kind)
         return arg
     end
 

--- a/src/components/strings.jl
+++ b/src/components/strings.jl
@@ -66,10 +66,11 @@ function parse_string_or_cmd(ps::ParseState, prefixed = false)
 
     # there are interpolations in the string
     if prefixed != false || iscmd
-        val = istrip ? ps.t.val[4:end - 3] : ps.t.val[2:end - 1]
+        t_str = val(ps.t, ps)
+        _val = istrip ? t_str[4:end - 3] : t_str[2:end - 1]
         expr = LITERAL(sfullspan, sspan,
-            iscmd ? replace(val, "\\`", "`") :
-                    replace(val, "\\\"", "\""), ps.t.kind)
+            iscmd ? replace(_val, "\\`", "`") :
+                    replace(_val, "\\\"", "\""), ps.t.kind)
         if istrip
             adjust_lcp(expr)
             ret = EXPR{StringH}(Any[expr], sfullspan, sspan)
@@ -78,7 +79,7 @@ function parse_string_or_cmd(ps::ParseState, prefixed = false)
         end
     else
         ret = EXPR{StringH}(Any[], sfullspan, sspan)
-        input = IOBuffer(ps.t.val)
+        input = IOBuffer(val(ps.t, ps))
         startbytes = istrip ? 3 : 1
         seek(input, startbytes)
         b = IOBuffer()

--- a/src/hints.jl
+++ b/src/hints.jl
@@ -94,7 +94,7 @@ function error_unexpected(ps, tok)
                          "Unexpected [")
     elseif tok.kind == Tokens.ERROR
         return make_error(ps, tok.startbyte:tok.endbyte, Diagnostics.UnexpectedRSquare,
-                            "Unexpected token $(Tokenize.Tokens.untokenize(tok))")
+                            "Unexpected token $(val(tok, ps))")
     else
         error("Internal error")
     end

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -43,7 +43,7 @@ struct IDENTIFIER
     val::String
     IDENTIFIER(fullspan::Int, span::UnitRange{Int}, val::String) = new(fullspan, span, val)
 end
-IDENTIFIER(ps::ParseState) = IDENTIFIER(ps.nt.startbyte - ps.t.startbyte, 1:(ps.t.endbyte - ps.t.startbyte + 1), untokenize(ps.t))
+IDENTIFIER(ps::ParseState) = IDENTIFIER(ps.nt.startbyte - ps.t.startbyte, 1:(ps.t.endbyte - ps.t.startbyte + 1), val(ps.t, ps))
 
 struct PUNCTUATION
     kind::Tokenize.Tokens.Kind
@@ -79,7 +79,7 @@ function LITERAL(ps::ParseState)
        ps.t.kind == Tokens.CMD || ps.t.kind == Tokens.TRIPLE_CMD
         return parse_string_or_cmd(ps)
     else
-        LITERAL(ps.nt.startbyte - ps.t.startbyte, 1:(ps.t.endbyte - ps.t.startbyte + 1), ps.t.val, ps.t.kind)
+        LITERAL(ps.nt.startbyte - ps.t.startbyte, 1:(ps.t.endbyte - ps.t.startbyte + 1), val(ps.t, ps), ps.t.kind)
     end
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -179,22 +179,22 @@ macro catcherror(ps, body)
 end
 
 
-isidentifier(t::Token) = t.kind == Tokens.IDENTIFIER
+isidentifier(t::AbstractToken) = t.kind == Tokens.IDENTIFIER
 
-isliteral(t::Token) = Tokens.begin_literal < t.kind < Tokens.end_literal
+isliteral(t::AbstractToken) = Tokens.begin_literal < t.kind < Tokens.end_literal
 
-isbool(t::Token) =  Tokens.TRUE ≤ t.kind ≤ Tokens.FALSE
-iscomma(t::Token) =  t.kind == Tokens.COMMA
+isbool(t::AbstractToken) =  Tokens.TRUE ≤ t.kind ≤ Tokens.FALSE
+iscomma(t::AbstractToken) =  t.kind == Tokens.COMMA
 
-iskw(t::Token) = Tokens.iskeyword(t.kind)
+iskw(t::AbstractToken) = Tokens.iskeyword(t.kind)
 
-isinstance(t::Token) = isidentifier(t) ||
+isinstance(t::AbstractToken) = isidentifier(t) ||
                        isliteral(t) ||
                        isbool(t) ||
                        iskw(t)
 
 
-ispunctuation(t::Token) = t.kind == Tokens.COMMA ||
+ispunctuation(t::AbstractToken) = t.kind == Tokens.COMMA ||
                           t.kind == Tokens.END ||
                           Tokens.LSQUARE ≤ t.kind ≤ Tokens.RPAREN || 
                           t.kind == Tokens.AT_SIGN
@@ -635,7 +635,7 @@ is_pairarrow(x) = x isa OPERATOR && x.kind == Tokens.PAIR_ARROW && x.dot == fals
 is_in(x) = x isa OPERATOR && x.kind == Tokens.IN && x.dot == false
 is_elof(x) = x isa OPERATOR && x.kind == Tokens.ELEMENT_OF && x.dot == false
 is_colon(x) = x isa OPERATOR && x.kind == Tokens.COLON
-is_prime(x) = x isa OPERATOR && x.kind == Tokens.PRIME 
+is_prime(x) = x isa OPERATOR && x.kind == Tokens.PRIME
 is_cond(x) = x isa OPERATOR && x.kind == Tokens.CONDITIONAL
 is_where(x) = x isa OPERATOR && x.kind == Tokens.WHERE
 is_anon_func(x) = x isa OPERATOR && x.kind == Tokens.ANON_FUNC
@@ -693,3 +693,5 @@ for t in (CSTParser.IDENTIFIER, CSTParser.OPERATOR, CSTParser.LITERAL, CSTParser
     Base.next(x::t, s) = x, s + 1
     Base.done(x::t, s) = true
 end
+
+@inline val(token::RawToken, ps::ParseState) = String(ps.l.io.data[token.startbyte+1:token.endbyte+1])


### PR DESCRIPTION
This changes CSTParser to use the RawToken form in Tokenize.jl and extract the strings from the underlying IOBuffer when needed.
It changes the time to parse `inference.jl` from 41 ms to 31 ms on my computer and reduces the number of allocations from 268k to 175k or 13MB -> 8MB, (needs https://github.com/KristofferC/Tokenize.jl/pull/114 for comparison).
I believe this should be safe from a user point of view because all the strings that are left in the AST are copied out from the buffer.

There are a few tests (5 of them) that are failing and I can't really dig into it right now, it is probably not too hard to fix them.