### PR TITLE
For the record: Unparameterize EXPR

### DIFF
--- a/src/CSTParser.jl
+++ b/src/CSTParser.jl
@@ -81,7 +81,7 @@ function parse_expression(ps::ParseState)
         return error_token(ps, ps.t)
     else
         ps.errored = true
-        return EXPR{ERROR}(Any[INSTANCE(ps)])
+        return EXPR(ERROR, Any[INSTANCE(ps)])
     end
 
     while !closer(ps)
@@ -140,7 +140,7 @@ function parse_kw(ps)
     elseif k == Tokens.ELSE || k == Tokens.ELSEIF || k == Tokens.CATCH || k == Tokens.FINALLY
         ret = IDENTIFIER(ps)
         ps.errored = true
-        return EXPR{ERROR}(Any[])
+        return EXPR(ERROR, Any[])
     elseif k == Tokens.ABSTRACT
         return parse_abstract(ps)
     elseif k == Tokens.BITSTYPE
@@ -198,16 +198,16 @@ function parse_compound(ps::ParseState, ret)
     elseif (ret isa IDENTIFIER || (ret isa BinarySyntaxOpCall && is_dot(ret.op))) && (ps.nt.kind == Tokens.STRING || ps.nt.kind == Tokens.TRIPLE_STRING)
         next(ps)
         @catcherror ps arg = parse_string_or_cmd(ps, ret)
-        ret = EXPR{x_Str}(Any[ret, arg])
+        ret = EXPR(x_Str, Any[ret, arg])
     # Suffix on x_str
-    elseif ret isa EXPR{x_Str} && ps.nt.kind == Tokens.IDENTIFIER
+    elseif is_xstr(ret) && ps.nt.kind == Tokens.IDENTIFIER
         arg = IDENTIFIER(next(ps))
         push!(ret, LITERAL(arg.fullspan, arg.span, ps.t.val, Tokens.STRING))
     elseif (ret isa IDENTIFIER || (ret isa BinarySyntaxOpCall && is_dot(ret.op))) && ps.nt.kind == Tokens.CMD
         next(ps)
         @catcherror ps arg = parse_string_or_cmd(ps, ret)
-        ret = EXPR{x_Cmd}(Any[ret, arg])
-    elseif ret isa EXPR{x_Cmd} && ps.nt.kind == Tokens.IDENTIFIER
+        ret = EXPR(x_Cmd, Any[ret, arg])
+    elseif is_xcmd(EXPR) && ps.nt.kind == Tokens.IDENTIFIER
         arg = IDENTIFIER(next(ps))
         push!(ret, LITERAL(arg.fullspan, 1:span(arg), ps.t.val, Tokens.STRING))
     elseif ret isa UnarySyntaxOpCall && is_prime(ret.arg2)
@@ -227,21 +227,21 @@ function parse_compound(ps::ParseState, ret)
             # TODO: Which operator? How do we get at the spelling
             diag_range, [], "Unexpected operator"
         ))
-        return EXPR{ERROR}(Any[INSTANCE(ps)])
+        return EXPR(ERROR, Any[INSTANCE(ps)])
     elseif ps.nt.kind == Tokens.IDENTIFIER
         ps.errored = true
         push!(ps.diagnostics, Diagnostic{Diagnostics.UnexpectedIdentifier}(
             ps.nt.startbyte:ps.nt.endbyte, [], "Unexpected identifier"
         ))
-        return EXPR{ERROR}(Any[INSTANCE(ps)])
+        return EXPR(ERROR, Any[INSTANCE(ps)])
     elseif ps.nt.kind == Tokens.ERROR
         return error_token(ps, ps.nt)
     else
         ps.errored = true
-        return EXPR{ERROR}(Any[INSTANCE(ps)])
+        return EXPR(ERROR, Any[INSTANCE(ps)])
     end
     if ps.errored
-        return EXPR{ERROR}(Any[INSTANCE(ps)])
+        return EXPR(ERROR, Any[INSTANCE(ps)])
     end
     return ret
 end
@@ -255,12 +255,12 @@ function parse_paren(ps::ParseState)
     args = Any[PUNCTUATION(ps)]
     @catcherror ps @default ps @nocloser ps inwhere @closer ps paren parse_comma_sep(ps, args, false, true, true)
 
-    if ((length(args) == 2 && !(args[2] isa UnarySyntaxOpCall && is_dddot(args[2].arg2))) || (length(args) == 1 && args[1] isa EXPR{Block})) && ((ps.ws.kind != SemiColonWS || (length(args) == 2 && args[2] isa EXPR{Block})) && !(args[2] isa EXPR{Parameters}))
+    if ((length(args) == 2 && !(args[2] isa UnarySyntaxOpCall && is_dddot(args[2].arg2))) || (length(args) == 1 && is_block(args[1]))) && ((ps.ws.kind != SemiColonWS || (length(args) == 2 && is_block(args[2]))) && !(is_parameters(args[2])))
         push!(args, PUNCTUATION(next(ps)))
-        ret = EXPR{InvisBrackets}(args)
+        ret = EXPR(InvisBrackets, args)
     else
         push!(args, PUNCTUATION(next(ps)))
-        ret = EXPR{TupleH}(args)
+        ret = EXPR(TupleH, args)
     end
 
     return ret
@@ -275,7 +275,7 @@ function parse(str::String, cont = false)
     ps = ParseState(str)
     x, ps = parse(ps, cont)
     if ps.errored
-        x = EXPR{ERROR}(Any[])
+        x = EXPR(ERROR, Any[])
     end
     return x
 end
@@ -291,14 +291,14 @@ function parse_doc(ps::ParseState)
         end
 
         ret = parse_expression(ps)
-        ret = EXPR{MacroCall}(Any[GlobalRefDOC, doc, ret])
+        ret = EXPR(MacroCall, Any[GlobalRefDOC, doc, ret])
     elseif ps.nt.kind == Tokens.IDENTIFIER && ps.nt.val == "doc" && (ps.nnt.kind == Tokens.STRING || ps.nnt.kind == Tokens.TRIPLE_STRING)
         doc = IDENTIFIER(next(ps))
         next(ps)
         @catcherror ps arg = parse_string_or_cmd(ps, doc)
-        doc = EXPR{x_Str}(Any[doc, arg])
+        doc = EXPR(x_Str, Any[doc, arg])
         ret = parse_expression(ps)
-        ret = EXPR{MacroCall}(Any[GlobalRefDOC, doc, ret])
+        ret = EXPR(MacroCall, Any[GlobalRefDOC, doc, ret])
     else
         ret = parse_expression(ps)
     end
@@ -307,13 +307,13 @@ end
 
 function parse(ps::ParseState, cont = false)
     if ps.l.io.size == 0
-        return (cont ? EXPR{FileH}(Any[]) : nothing), ps
+        return (cont ? EXPR(FileH, Any[]) : nothing), ps
     end
     last_line = 0
     curr_line = 0
 
     if cont
-        top = EXPR{FileH}(Any[])
+        top = EXPR(FileH, Any[])
         if ps.nt.kind == Tokens.WHITESPACE || ps.nt.kind == Tokens.COMMENT
             next(ps)
             push!(top, LITERAL(ps.nt.startbyte, 1:ps.nt.startbyte, "", Tokens.NOTHING))
@@ -324,10 +324,10 @@ function parse(ps::ParseState, cont = false)
             ret = parse_doc(ps)
 
             # join semicolon sep items
-            if curr_line == last_line && last(top.args) isa EXPR{TopLevel}
+            if curr_line == last_line && is_toplevel(last(top.args))
                 push!(last(top.args), ret)
             elseif ps.ws.kind == SemiColonWS
-                push!(top, EXPR{TopLevel}(Any[ret]))
+                push!(top, EXPR(TopLevel, Any[ret]))
             else
                 push!(top, ret)
             end
@@ -341,7 +341,7 @@ function parse(ps::ParseState, cont = false)
             top = parse_doc(ps)
             last_line = ps.nt.startpos[1]
             if ps.ws.kind == SemiColonWS
-                top = EXPR{TopLevel}(Any[top])
+                top = EXPR(TopLevel, Any[top])
                 while ps.ws.kind == SemiColonWS && ps.nt.startpos[1] == last_line && ps.nt.kind != Tokens.ENDMARKER
                     ret = parse_doc(ps)
                     push!(top, ret)
@@ -377,9 +377,8 @@ function parse_directory(path::String, proj = Project(path, []))
 end
 
 
-
 ischainable(t::Token) = t.kind == Tokens.PLUS || t.kind == Tokens.STAR || t.kind == Tokens.APPROX
 
-include("_precompile.jl")
-_precompile_()
+# include("_precompile.jl")
+# _precompile_()
 end

--- a/src/components/controlflow.jl
+++ b/src/components/controlflow.jl
@@ -1,7 +1,7 @@
 function parse_do(ps::ParseState, ret)
     kw = KEYWORD(next(ps))
 
-    args = EXPR{TupleH}(Any[])
+    args = EXPR(TupleH, Any[])
     @default ps @closer ps comma @closer ps block while !closer(ps)
         @catcherror ps a = parse_expression(ps)
 
@@ -14,7 +14,7 @@ function parse_do(ps::ParseState, ret)
     blockargs = Any[]
     @catcherror ps @default ps parse_block(ps, blockargs)
 
-    return EXPR{Do}(Any[ret, kw, args, EXPR{Block}(blockargs), PUNCTUATION(next(ps))])
+    return EXPR(Do, Any[ret, kw, args, EXPR(Block, blockargs), PUNCTUATION(next(ps))])
 end
 
 """
@@ -26,7 +26,7 @@ function parse_if(ps::ParseState, nested = false)
     # Parsing
     kw = KEYWORD(ps)
     if ps.ws.kind == NewLineWS || ps.ws.kind == SemiColonWS
-        return EXPR{ERROR}(Any[])
+        return EXPR(ERROR, Any[])
     end
     @catcherror ps cond = @default ps @closer ps block @closer ps ws parse_expression(ps)
 
@@ -35,12 +35,12 @@ function parse_if(ps::ParseState, nested = false)
     @catcherror ps @default ps @closer ps ifelse parse_block(ps, ifblockargs, (Tokens.END, Tokens.ELSE, Tokens.ELSEIF))
 
     if nested
-        ret = EXPR{If}(Any[cond, EXPR{Block}(ifblockargs)])
+        ret = EXPR(If, Any[cond, EXPR(Block, ifblockargs)])
     else
-        ret = EXPR{If}(Any[kw, cond, EXPR{Block}(ifblockargs)])
+        ret = EXPR(If, Any[kw, cond, EXPR(Block, ifblockargs)])
     end
 
-    elseblock = EXPR{Block}(Any[], 0, 1:0)
+    elseblock = EXPR(Block, Any[], 0, 1:0)
     if ps.nt.kind == Tokens.ELSEIF
         push!(ret, KEYWORD(next(ps)))
 
@@ -75,24 +75,24 @@ function parse_let(ps::ParseState)
     blockargs = Any[]
     @catcherror ps @default ps parse_block(ps, blockargs)
 
-    push!(args, EXPR{Block}(blockargs))
+    push!(args, EXPR(Block, blockargs))
     push!(args, KEYWORD(next(ps)))
 
-    return EXPR{Let}(args)
+    return EXPR(Let, args)
 end
 
 function parse_try(ps::ParseState)
     kw = KEYWORD(ps)
-    ret = EXPR{Try}(Any[kw])
+    ret = EXPR(Try, Any[kw])
 
     tryblockargs = Any[]
     @catcherror ps @default ps @closer ps trycatch parse_block(ps, tryblockargs, (Tokens.END, Tokens.CATCH, Tokens.FINALLY))
-    push!(ret, EXPR{Block}(tryblockargs))
+    push!(ret, EXPR(Block, tryblockargs))
 
     # try closing early
     if ps.nt.kind == Tokens.END
         push!(ret, FALSE)
-        push!(ret, EXPR{Block}(Any[], 0, 1:0))
+        push!(ret, EXPR(Block, Any[], 0, 1:0))
         push!(ret, KEYWORD(next(ps)))
         return ret
     end
@@ -104,7 +104,7 @@ function parse_try(ps::ParseState)
         if ps.nt.kind == Tokens.FINALLY || ps.nt.kind == Tokens.END
             push!(ret, KEYWORD(ps))
             caught = FALSE
-            catchblock = EXPR{Block}(Any[], 0, 1:0)
+            catchblock = EXPR(Block, Any[], 0, 1:0)
         else
             start_col = ps.t.startpos[2] + 4
             push!(ret, KEYWORD(ps))
@@ -113,7 +113,7 @@ function parse_try(ps::ParseState)
             else
                 @catcherror ps caught = @default ps @closer ps ws @closer ps trycatch parse_expression(ps)
             end
-            catchblock = EXPR{Block}(Any[], 0, 1:0)
+            catchblock = EXPR(Block, Any[], 0, 1:0)
             @catcherror ps @default ps @closer ps trycatch parse_block(ps, catchblock, (Tokens.END, Tokens.FINALLY))
             if !(caught isa IDENTIFIER || caught == FALSE)
                 unshift!(catchblock, caught)
@@ -122,7 +122,7 @@ function parse_try(ps::ParseState)
         end
     else
         caught = FALSE
-        catchblock = EXPR{Block}(Any[], 0, 1:0)
+        catchblock = EXPR(Block, Any[], 0, 1:0)
     end
     push!(ret, caught)
     push!(ret, catchblock)
@@ -133,7 +133,7 @@ function parse_try(ps::ParseState)
             ret.args[4] = FALSE
         end
         push!(ret, KEYWORD(next(ps)))
-        finallyblock = EXPR{Block}(Any[], 0, 1:0)
+        finallyblock = EXPR(Block, Any[], 0, 1:0)
         @catcherror ps parse_block(ps, finallyblock)
         push!(ret, finallyblock)
     end

--- a/src/components/genericblocks.jl
+++ b/src/components/genericblocks.jl
@@ -3,7 +3,7 @@ function parse_begin(ps::ParseState)
     blockargs = Any[]
     @catcherror ps arg = @default ps parse_block(ps, blockargs, (Tokens.END,), true)
 
-    return EXPR{Begin}(Any[kw, EXPR{Block}(blockargs), KEYWORD(next(ps))])
+    return EXPR(Begin, Any[kw, EXPR(Block, blockargs), KEYWORD(next(ps))])
 end
 
 function parse_quote(ps::ParseState)
@@ -11,7 +11,7 @@ function parse_quote(ps::ParseState)
     blockargs = Any[]
     @catcherror ps @default ps parse_block(ps, blockargs)
 
-    return EXPR{Quote}(Any[kw, EXPR{Block}(blockargs), KEYWORD(next(ps))])
+    return EXPR(Quote, Any[kw, EXPR(Block, blockargs), KEYWORD(next(ps))])
 end
 
 """
@@ -21,10 +21,11 @@ Parses an array of expressions (stored in ret) until 'end' is the next token.
 Returns `ps` the token before the closing `end`, the calling function is
 assumed to handle the closer.
 """
-function parse_block(ps::ParseState, ret::EXPR{Block}, closers = (Tokens.END,), docable = false)
+function parse_block(ps::ParseState, ret::EXPR, closers = (Tokens.END,), docable = false)
+    ret.head != Block && unhandled_head(ret.head)
     parse_block(ps, ret.args, closers, docable)
     update_span!(ret)
-    return 
+    return
 end
 
 
@@ -41,5 +42,5 @@ function parse_block(ps::ParseState, ret::Vector{Any}, closers = (Tokens.END,), 
         end
         push!(ret, a)
     end
-    return 
+    return
 end

--- a/src/components/macros.jl
+++ b/src/components/macros.jl
@@ -10,7 +10,7 @@ function parse_macro(ps::ParseState)
     blockargs = Any[]
     @catcherror ps @default ps parse_block(ps, blockargs)
 
-    return EXPR{Macro}(Any[kw, sig, EXPR{Block}(blockargs), KEYWORD(next(ps))])
+    return EXPR(Macro, Any[kw, sig, EXPR(Block, blockargs), KEYWORD(next(ps))])
 end
 
 """
@@ -20,23 +20,23 @@ Parses a macro call. Expects to start on the `@`.
 """
 function parse_macrocall(ps::ParseState)
     at = PUNCTUATION(ps)
-    mname = EXPR{MacroName}(Any[at, IDENTIFIER(next(ps))])
+    mname = EXPR(MacroName, Any[at, IDENTIFIER(next(ps))])
 
     # Handle cases with @ at start of dotted expressions
     if ps.nt.kind == Tokens.DOT && isemptyws(ps.ws)
         while ps.nt.kind == Tokens.DOT
             op = OPERATOR(next(ps))
             if ps.nt.kind != Tokens.IDENTIFIER
-                return EXPR{ERROR}(Any[])
+                return EXPR(ERROR, Any[])
             end
             nextarg = IDENTIFIER(next(ps))
-            mname = BinarySyntaxOpCall(mname, op, Quotenode(nextarg))
+            mname = BinarySyntaxOpCall(mname, op, QuoteNode(nextarg))
         end
     end
     args = Any[mname]
 
     if ps.nt.kind == Tokens.COMMA
-        return EXPR{MacroCall}(args)
+        return EXPR(MacroCall, args)
     end
     if isemptyws(ps.ws) && ps.nt.kind == Tokens.LPAREN
         push!(args, PUNCTUATION(next(ps)))
@@ -52,5 +52,5 @@ function parse_macrocall(ps::ParseState)
             end
         end
     end
-    return EXPR{MacroCall}(args)
+    return EXPR(MacroCall, args)
 end

--- a/src/components/modules.jl
+++ b/src/components/modules.jl
@@ -6,13 +6,13 @@ function parse_module(ps::ParseState)
         @catcherror ps arg = @precedence ps 15 @closer ps block @closer ps ws parse_expression(ps)
     end
 
-    block = EXPR{Block}(Any[])
+    block = EXPR(Block, Any[])
     @default ps while ps.nt.kind !== Tokens.END
         @catcherror ps a = @closer ps block parse_doc(ps)
         push!(block, a)
     end
 
-    return EXPR{(kw isa KEYWORD{Tokens.MODULE} ? ModuleH : BareModule)}(Any[kw, arg, block, KEYWORD(next(ps))])
+    return EXPR((kw isa KEYWORD{Tokens.MODULE} ? ModuleH : BareModule), Any[kw, arg, block, KEYWORD(next(ps))])
 end
 
 function parse_dot_mod(ps::ParseState, is_colon = false)
@@ -43,9 +43,9 @@ function parse_dot_mod(ps::ParseState, is_colon = false)
         if ps.nt.kind == Tokens.AT_SIGN
             at = PUNCTUATION(next(ps))
             a = INSTANCE(next(ps))
-            push!(args, EXPR{MacroName}(Any[at, a]))
+            push!(args, EXPR(MacroName, Any[at, a]))
         elseif ps.nt.kind == Tokens.LPAREN
-            a = EXPR{InvisBrackets}(Any[PUNCTUATION(next(ps))])
+            a = EXPR(InvisBrackets, Any[PUNCTUATION(next(ps))])
             @catcherror ps push!(a, @default ps @closer ps paren parse_expression(ps))
             push!(a, PUNCTUATION(next(ps)))
             push!(args, a)
@@ -81,9 +81,9 @@ function parse_imports(ps::ParseState)
     arg = parse_dot_mod(ps)
 
     if ps.nt.kind != Tokens.COMMA && ps.nt.kind != Tokens.COLON
-        ret = EXPR{kwt}(vcat(kw, arg))
+        ret = EXPR(kwt, vcat(kw, arg))
     elseif ps.nt.kind == Tokens.COLON
-        ret = EXPR{kwt}(vcat(kw, arg))
+        ret = EXPR(kwt, vcat(kw, arg))
         push!(ret, OPERATOR(next(ps)))
 
         @catcherror ps arg = parse_dot_mod(ps, true)
@@ -94,7 +94,7 @@ function parse_imports(ps::ParseState)
             append!(ret, arg)
         end
     else
-        ret = EXPR{kwt}(vcat(kw, arg))
+        ret = EXPR(kwt, vcat(kw, arg))
         while ps.nt.kind == Tokens.COMMA
             push!(ret, PUNCTUATION(next(ps)))
             @catcherror ps arg = parse_dot_mod(ps)
@@ -115,7 +115,7 @@ function parse_export(ps::ParseState)
         push!(args, arg)
     end
 
-    return EXPR{Export}(args)
+    return EXPR(Export, args)
 end
 
 

--- a/src/components/prefixkw.jl
+++ b/src/components/prefixkw.jl
@@ -2,35 +2,35 @@ function parse_const(ps::ParseState)
     kw = KEYWORD(ps)
     @catcherror ps arg = @default ps parse_expression(ps)
 
-    return EXPR{Const}(Any[kw, arg])
+    return EXPR(Const, Any[kw, arg])
 end
 
 function parse_global(ps::ParseState)
     kw = KEYWORD(ps)
     @catcherror ps arg = parse_expression(ps)
 
-    return EXPR{Global}(Any[kw, arg])
+    return EXPR(Global, Any[kw, arg])
 end
 
 function parse_local(ps::ParseState)
     kw = KEYWORD(ps)
     @catcherror ps arg = @default ps parse_expression(ps)
 
-    return EXPR{Local}(Any[kw, arg])
+    return EXPR(Local, Any[kw, arg])
 end
 
 function parse_return(ps::ParseState)
     kw = KEYWORD(ps)
     @catcherror ps args = @default ps closer(ps) ? NOTHING : parse_expression(ps)
 
-    return EXPR{Return}(Any[kw, args])
+    return EXPR(Return, Any[kw, args])
 end
 
 function parse_end(ps::ParseState)
     ret = IDENTIFIER(ps)
     if !ps.closer.square
         ps.errored = true
-        return EXPR{ERROR}(Any[])
+        return EXPR(ERROR, Any[])
     end
     return ret
 end

--- a/src/components/strings.jl
+++ b/src/components/strings.jl
@@ -29,7 +29,7 @@ function parse_string_or_cmd(ps::ParseState, prefixed = false)
     iscmd = ps.t.kind == Tokens.CMD || ps.t.kind == Tokens.TRIPLE_CMD
 
     if ps.errored
-        return EXPR{ERROR}(Any[])
+        return EXPR(ERROR, Any[])
     end
 
     lcp = nothing
@@ -72,12 +72,12 @@ function parse_string_or_cmd(ps::ParseState, prefixed = false)
                     replace(val, "\\\"", "\""), ps.t.kind)
         if istrip
             adjust_lcp(expr)
-            ret = EXPR{StringH}(Any[expr], sfullspan, sspan)
+            ret = EXPR(StringH, Any[expr], sfullspan, sspan)
         else
             return expr
         end
     else
-        ret = EXPR{StringH}(Any[], sfullspan, sspan)
+        ret = EXPR(StringH, Any[], sfullspan, sspan)
         input = IOBuffer(ps.t.val)
         startbytes = istrip ? 3 : 1
         seek(input, startbytes)
@@ -108,7 +108,7 @@ function parse_string_or_cmd(ps::ParseState, prefixed = false)
                     skip(input, 1)
                     ps1 = ParseState(input)
                     @catcherror ps interp = @closer ps1 paren parse_expression(ps1)
-                    call = UnarySyntaxOpCall(op, EXPR{InvisBrackets}(Any[lparen, interp, rparen]))
+                    call = UnarySyntaxOpCall(op, EXPR(InvisBrackets, Any[lparen, interp, rparen]))
                     push!(ret.args, call)
                     # Compared to flisp/JuliaParser, we have an extra lookahead token,
                     # so we need to back up one here

--- a/src/components/types.jl
+++ b/src/components/types.jl
@@ -6,12 +6,12 @@ function parse_abstract(ps::ParseState)
 
         @catcherror ps sig = @default ps @closer ps block parse_expression(ps)
 
-        ret = EXPR{Abstract}(Any[kw1, kw2, sig, KEYWORD(next(ps))])
+        ret = EXPR(Abstract, Any[kw1, kw2, sig, KEYWORD(next(ps))])
     else
         kw = KEYWORD(ps)
         @catcherror ps sig = @default ps parse_expression(ps)
 
-        ret = EXPR{Abstract}(Any[kw, sig])
+        ret = EXPR(Abstract, Any[kw, sig])
     end
     return ret
 end
@@ -22,7 +22,7 @@ function parse_bitstype(ps::ParseState)
     @catcherror ps arg1 = @default ps @closer ps ws @closer ps wsop parse_expression(ps)
     @catcherror ps arg2 = @default ps parse_expression(ps)
 
-    return EXPR{Bitstype}(Any[kw, arg1, arg2])
+    return EXPR(Bitstype, Any[kw, arg1, arg2])
 end
 
 function parse_primitive(ps::ParseState)
@@ -32,7 +32,7 @@ function parse_primitive(ps::ParseState)
         @catcherror ps sig = @default ps @closer ps ws @closer ps wsop parse_expression(ps)
         @catcherror ps arg = @default ps @closer ps block parse_expression(ps)
 
-        ret = EXPR{Primitive}(Any[kw1, kw2, sig, arg, KEYWORD(next(ps))])
+        ret = EXPR(Primitive, Any[kw1, kw2, sig, arg, KEYWORD(next(ps))])
     else
         ret = IDENTIFIER(ps)
     end
@@ -45,7 +45,7 @@ function parse_typealias(ps::ParseState)
     @catcherror ps arg1 = @closer ps ws @closer ps wsop parse_expression(ps)
     @catcherror ps arg2 = parse_expression(ps)
 
-    return EXPR{TypeAlias}(Any[kw, arg1, arg2])
+    return EXPR(TypeAlias, Any[kw, arg1, arg2])
 end
 
 function parse_mutable(ps::ParseState)
@@ -68,5 +68,5 @@ function parse_struct(ps::ParseState, mutable)
     blockargs = Any[]
     @catcherror ps @default ps parse_block(ps, blockargs)
     
-    return EXPR{mutable ? Mutable : Struct}(Any[kw, sig, EXPR{Block}(blockargs), KEYWORD(next(ps))])
+    return EXPR(mutable ? Mutable : Struct, Any[kw, sig, EXPR(Block, blockargs), KEYWORD(next(ps))])
 end

--- a/src/display.jl
+++ b/src/display.jl
@@ -1,5 +1,5 @@
-function AbstractTrees.printnode(io::IO, x::EXPR{T}) where T
-    print(io, T, "  ", x.fullspan, " (", x.span, ")")
+function AbstractTrees.printnode(io::IO, x::EXPR)
+    print(io, x.head, "  ", x.fullspan, " (", x.span, ")")
     print(io)
 end
 Base.show(io::IO, x::EXPR) = AbstractTrees.print_tree(io, x, 3)

--- a/src/hints.jl
+++ b/src/hints.jl
@@ -64,7 +64,7 @@ function make_error(ps, range, code, text)
     ps.errored = true
     ps.error_code = code
     push!(ps.diagnostics, Diagnostic{code}(range, [], text))
-    return EXPR{ERROR}(Any[INSTANCE(ps)])
+    return EXPR(ERROR, Any[INSTANCE(ps)])
 end
 
 function error_unexpected(ps, tok)
@@ -115,6 +115,6 @@ function error_token(ps, tok)
         return error_eof(ps, ps.t.endbyte+1, Diagnostics.UnexpectedCmdEnd, "Unexpected end of command")
     else
         ps.errored = true
-        return EXPR{ERROR}(Any[INSTANCE(ps)])
+        return EXPR(ERROR, Any[INSTANCE(ps)])
     end
 end

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -19,6 +19,73 @@ const PrimeOp       = 16
 const DddotOp       = 7
 const AnonFuncOp    = 14
 
+# Heads
+@enum(Head,
+Call,
+ComparisonOpCall,
+ChainOpCall,
+ColonOpCall,
+Abstract,
+Begin,
+Bitstype,
+Block,
+Cell1d,
+Const,
+Comparison,
+Curly,
+Do,
+ERROR,
+Filter,
+Flatten,
+For,
+FunctionDef,
+Generator,
+Global,
+GlobalRefDoc,
+If,
+Kw,
+Let,
+Local,
+Macro,
+MacroCall,
+MacroName,
+Mutable,
+Parameters,
+Primitive,
+Quote,
+Quotenode,
+InvisBrackets,
+StringH,
+Struct,
+Try,
+TupleH,
+TypeAlias,
+FileH,
+Return,
+While,
+x_Cmd,
+x_Str,
+
+ModuleH,
+BareModule,
+TopLevel,
+Export,
+Import,
+ImportAll,
+Using,
+
+Comprehension,
+DictComprehension,
+TypedComprehension,
+Hcat,
+TypedHcat,
+Ref,
+Row,
+Vcat,
+TypedVcat,
+Vect,
+)
+
 
 # Invariants:
 # if !isempty(e.args)
@@ -26,7 +93,8 @@ const AnonFuncOp    = 14
 #   first(e.span) == first(first(e.args).span)
 #   last(e.span) == sum(x->x.fullspan, e.args[1:end-1]) + last(last(e.args).span)
 # end
-mutable struct EXPR{T}
+mutable struct EXPR
+    head::Head
     args::Vector
     # The full width of this expression including any whitespace
     fullspan::Int
@@ -34,8 +102,6 @@ mutable struct EXPR{T}
     # excluding any leading/trailing whitespace or other trivia. 1-indexed
     span::UnitRange{Int}
 end
-
-abstract type ERROR end
 
 struct IDENTIFIER
     fullspan::Int
@@ -104,8 +170,8 @@ function update_span!(x::EXPR)
     return 
 end
 
-function EXPR{T}(args::Vector) where {T}
-    ret = EXPR{T}(args, 0, 1:0)
+function EXPR(T, args::Vector)
+    ret = EXPR(T, args, 0, 1:0)
     update_span!(ret)
     ret
 end
@@ -152,7 +218,7 @@ end
 
 function INSTANCE(ps::ParseState)
     if ps.errored
-        return EXPR{ERROR}(Any[], ps.nt.startbyte - ps.t.startbyte, 1:(ps.t.endbyte - ps.t.startbyte + 1))
+        return EXPR(ERROR, Any[], ps.nt.startbyte - ps.t.startbyte, 1:(ps.t.endbyte - ps.t.startbyte + 1))
     elseif isidentifier(ps.t)
         return IDENTIFIER(ps)
     elseif isliteral(ps.t)
@@ -176,15 +242,13 @@ mutable struct File
     ast::EXPR
     errors
 end
-File(path::String) = File([], [], path, EXPR{FileH}(Any[]), [])
+File(path::String) = File([], [], path, EXPR(FileH, Any[]), [])
 
 mutable struct Project
     path::String
     files::Vector{File}
 end
 
-abstract type Head end
-abstract type Call <: Head end
 
 mutable struct UnaryOpCall
     op::OPERATOR
@@ -268,71 +332,9 @@ end
 
 AbstractTrees.children(x::ConditionalOpCall) = vcat(x.cond, x.op1, x.arg1, x.op2, x.arg2)
 
-abstract type ComparisonOpCall <: Head end
-abstract type ChainOpCall <: Head end
-abstract type ColonOpCall <: Head end
-abstract type Abstract <: Head end
-abstract type Begin <: Head end
-abstract type Bitstype <: Head end
-abstract type Block <: Head end
-abstract type Cell1d <: Head end
-abstract type Const <: Head end
-abstract type Comparison <: Head end
-abstract type Curly <: Head end
-abstract type Do <: Head end
-abstract type Filter <: Head end
-abstract type Flatten <: Head end
-abstract type For <: Head end
-abstract type FunctionDef <: Head end
-abstract type Generator <: Head end
-abstract type Global <: Head end
-abstract type GlobalRefDoc <: Head end
-abstract type If <: Head end
-abstract type Kw <: Head end
-abstract type Let <: Head end
-abstract type Local <: Head end
-abstract type Macro <: Head end
-abstract type MacroCall <: Head end
-abstract type MacroName <: Head end
-abstract type Mutable <: Head end
-abstract type Parameters <: Head end
-abstract type Primitive <: Head end
-abstract type Quote <: Head end
-abstract type Quotenode <: Head end
-abstract type InvisBrackets <: Head end
-abstract type StringH <: Head end
-abstract type Struct <: Head end
-abstract type Try <: Head end
-abstract type TupleH <: Head end
-abstract type TypeAlias <: Head end
-abstract type FileH <: Head end
-abstract type Return <: Head end
-abstract type While <: Head end
-abstract type x_Cmd <: Head end
-abstract type x_Str <: Head end
-
-abstract type ModuleH <: Head end
-abstract type BareModule <: Head end
-abstract type TopLevel <: Head end
-abstract type Export <: Head end
-abstract type Import <: Head end
-abstract type ImportAll <: Head end
-abstract type Using <: Head end
-
-abstract type Comprehension <: Head end
-abstract type DictComprehension <: Head end
-abstract type TypedComprehension <: Head end
-abstract type Hcat <: Head end
-abstract type TypedHcat <: Head end
-abstract type Ref <: Head end
-abstract type Row <: Head end
-abstract type Vcat <: Head end
-abstract type TypedVcat <: Head end
-abstract type Vect <: Head end
-
-Quotenode(x) = EXPR{Quotenode}(Any[x])
+QuoteNode(x) = EXPR(Quotenode, Any[x])
 
 const TRUE = LITERAL(0, 1:0, "", Tokens.TRUE)
 const FALSE = LITERAL(0, 1:0, "", Tokens.FALSE)
 const NOTHING = LITERAL(0, 1:0, "", Tokens.NOTHING)
-const GlobalRefDOC = EXPR{GlobalRefDoc}(Any[], 0, 1:0)
+const GlobalRefDOC = EXPR(GlobalRefDoc, Any[], 0, 1:0)


### PR DESCRIPTION
This was just something I tested out to see the performance effect.

While first call performance is improved (10.6 seconds -> 7 seconds), run-time is actually pretty much unaffected.
Tests fail since I haven't fixed up `conversion.jl` properly yet.
The code is slightly uglier so depending on how urgent we consider the first call timing to be, this might not be so useful to do. Dispatching on Expr is kinda convenient.