### PR TITLE
Fix tests on 0.6

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,8 @@
+if VERSION < v"0.7.0-DEV.1053"
+    read(io, ::Type{String}) = readstring(io)
+    read(io, ::Type{Char}) = Base.read(io, Char)
+end
+
 function closer(ps::ParseState)
     (ps.closer.newline && ps.ws.kind == NewLineWS && ps.t.kind != Tokens.COMMA) ||
     (ps.closer.semicolon && ps.ws.kind == SemiColonWS) ||


### PR DESCRIPTION
Since we don't depend on Compat, we can't assume these methods exist on 0.6.
This is a femtocleaner-compatible way to fix the tests on 0.6 without requiring
Compat.