### PR TITLE
wip linearize if syntax

### DIFF
--- a/src/components/genericblocks.jl
+++ b/src/components/genericblocks.jl
@@ -24,7 +24,7 @@ assumed to handle the closer.
 function parse_block(ps::ParseState, ret::EXPR{Block}, closers = (Tokens.END,), docable = false)
     parse_block(ps, ret.args, closers, docable)
     update_span!(ret)
-    return 
+    return
 end
 
 
@@ -41,5 +41,5 @@ function parse_block(ps::ParseState, ret::Vector{Any}, closers = (Tokens.END,), 
         end
         push!(ret, a)
     end
-    return 
+    return
 end


### PR DESCRIPTION
A possible solution to what we talked about on slack on the nesting of if statements.

Here is an example:

```jl
julia> CSTParser.parse("""
       if cond1
          block1
       elseif cond2
          blockelseif2
          blockelseif1
       else
          blockelse
       end""")
CSTParser.If  89 (1:89)
├─ CSTParser.KEYWORD(IF, 3, 1:2)
├─ ID: cond1  9 (1:5)
├─ CSTParser.Block  8 (1:6)
│  └─ ID: block1  8 (1:6)
├─ CSTParser.KEYWORD(ELSEIF, 7, 1:6)
├─ ID: cond2  10 (1:5)
├─ CSTParser.Block  29 (1:28)
│  ├─ ID: blockelseif2  16 (1:12)
│  └─ ID: blockelseif1  13 (1:12)
├─ CSTParser.KEYWORD(ELSE, 9, 1:4)
├─ CSTParser.Block  11 (1:9)
│  └─ ID: blockelse  11 (1:9)
└─ CSTParser.KEYWORD(END, 3, 1:3)
```

Any opinions on this? 

If you like it, I can try update the tests and stuff.