### PR TITLE
Fix another UTF8 issue

### DIFF
--- a/src/components/strings.jl
+++ b/src/components/strings.jl
@@ -86,7 +86,8 @@ function parse_string_or_cmd(ps::ParseState, prefixed = false)
         while true
             if eof(input)
                 lspan = position(b)
-                str = tostr(b)[1:end - (istrip ? 3 : 1)]
+                str = tostr(b)
+                str = String(Vector{UInt8}(str)[1:end - (istrip ? 3 : 1)])
                 ex = LITERAL(lspan + ps.nt.startbyte - ps.t.endbyte - 1 + startbytes, 1:(lspan + startbytes), str, Tokens.STRING)
                 push!(ret.args, ex)
                 istrip && adjust_lcp(ex, true)

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -536,6 +536,7 @@ end
     @test CSTParser.parse("\"\"\" \" \"\"\"").val == " \" "
     @test CSTParser.parse("\"\"\"a\"\"\"").val == "a"
     @test CSTParser.parse("\"\"\"\"\"\"").val == ""
+    @test CSTParser.parse("\"\"\"aδ\"\"\"").val == "aδ"
     @test CSTParser.parse("\"\"\"\n\t \ta\n\n\t \tb\"\"\"").val == "a\n\nb"
     @test Expr(CSTParser.parse("\"\"\"\ta\n\tb \$c\n\td\n\"\"\"")) == Expr(:string, "\ta\n\tb ", :c, "\n\td\n")
     @test Expr(CSTParser.parse("\"\"\"\n\ta\n\tb \$c\n\td\n\"\"\"")) == Expr(:string, "\ta\n\tb ", :c, "\n\td\n")


### PR DESCRIPTION
There's more problems of this kind, which are caused by julia 0.7 allowing invalidly encoded data in a `String`, while julia 0.6 does not. However, we'd have to basically duplicate the julia 0.7 string handling here to make that work on 0.6, so it probably makes sense to just finish the 0.7 upgrade instead.