### PR TITLE
Fix operation order in where parsing of anonymous functions

### DIFF
--- a/src/components/functions.jl
+++ b/src/components/functions.jl
@@ -13,15 +13,14 @@ function parse_function(ps::ParseState)
         @catcherror ps sig = @default ps @closer ps inwhere @closer ps block @closer ps ws parse_expression(ps)
     end
 
-    while ps.nt.kind == Tokens.WHERE
-        @catcherror ps sig = @default ps @closer ps inwhere @closer ps block @closer ps ws parse_compound(ps, sig)
-    end
-
     if sig isa EXPR{InvisBrackets} && !(sig.args[2] isa EXPR{TupleH})
         sig = EXPR{TupleH}(sig.args)
     end
 
-    
+    while ps.nt.kind == Tokens.WHERE
+        @catcherror ps sig = @default ps @closer ps inwhere @closer ps block @closer ps ws parse_compound(ps, sig)
+    end
+
     blockargs = Any[]
     @catcherror ps @default ps parse_block(ps, blockargs)
 

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -84,6 +84,7 @@ end
     @test f("function f(a::T,b::T) where T end") == ["a", "b"]
     @test f("function f{T}(a::T,b::T) where T end") == ["a", "b"]
     @test f("function f{T}(a::T,b::T;c = 1) where T end") == ["a", "b", "c"]
+    @test f("function(args::Vararg{Any,N}) where N end") == ["args"]
 
     @test f("a -> a") == ["a"]
     @test f("a::T -> a") == ["a"]

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -255,12 +255,11 @@ end
         @test """function ()
             return
         end""" |> test_expr
+        @test """function (args::Vararg{Any,N}) where N
+            return
+        end""" |> test_expr
     end
 end
-
-
-
-
 
 @testset "Types" begin
     @testset "Abstract" begin


### PR DESCRIPTION
We need to first transform the InvisBrackets into the TupleH,
otherwise the WhereOpCall hides it. Fixes #72.