### PR TITLE
Speed up tree walking

### DIFF
--- a/src/components/functions.jl
+++ b/src/components/functions.jl
@@ -13,15 +13,14 @@ function parse_function(ps::ParseState)
         @catcherror ps sig = @default ps @closer ps inwhere @closer ps block @closer ps ws parse_expression(ps)
     end
 
-    while ps.nt.kind == Tokens.WHERE
-        @catcherror ps sig = @default ps @closer ps inwhere @closer ps block @closer ps ws parse_compound(ps, sig)
-    end
-
     if sig isa EXPR{InvisBrackets} && !(sig.args[2] isa EXPR{TupleH})
         sig = EXPR{TupleH}(sig.args)
     end
 
-    
+    while ps.nt.kind == Tokens.WHERE
+        @catcherror ps sig = @default ps @closer ps inwhere @closer ps block @closer ps ws parse_compound(ps, sig)
+    end
+
     blockargs = Any[]
     @catcherror ps @default ps parse_block(ps, blockargs)
 

--- a/src/components/strings.jl
+++ b/src/components/strings.jl
@@ -86,7 +86,8 @@ function parse_string_or_cmd(ps::ParseState, prefixed = false)
         while true
             if eof(input)
                 lspan = position(b)
-                str = tostr(b)[1:end - (istrip ? 3 : 1)]
+                str = tostr(b)
+                str = String(Vector{UInt8}(str)[1:end - (istrip ? 3 : 1)])
                 ex = LITERAL(lspan + ps.nt.startbyte - ps.t.endbyte - 1 + startbytes, 1:(lspan + startbytes), str, Tokens.STRING)
                 push!(ret.args, ex)
                 istrip && adjust_lcp(ex, true)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -39,8 +39,8 @@ is_where(x) = x isa OPERATOR && x.kind == Tokens.WHERE
 is_anon_func(x) = x isa OPERATOR && x.kind == Tokens.ANON_FUNC
 
 # PUNCTUATION
-is_punc(x) = x isa PUNCTUATION && 
-    x.kind == Tokens.COMMA && 
+is_punc(x) = x isa PUNCTUATION &&
+    x.kind == Tokens.COMMA &&
     x.kind == Tokens.LPAREN &&
     x.kind == Tokens.RPAREN &&
     x.kind == Tokens.LBRACE &&
@@ -67,7 +67,7 @@ is_importall(x) = x isa KEYWORD && x.kind == Tokens.IMPORTALL
 is_lit_string(x) = x isa LITERAL && (x.kind == Tokens.STRING || x.kind == Tokens.TRIPLE_STRING)
 
 is_valid_iterator(x) = false
-is_valid_iterator(x::BinarySyntaxOpCall) = is_eq(x.op) 
+is_valid_iterator(x::BinarySyntaxOpCall) = is_eq(x.op)
 is_valid_iterator(x::BinaryOpCall) = is_in(x.op) || is_elof(x.op)
 
 _arg_id(x) = x
@@ -236,8 +236,8 @@ end
 defines_struct(x) = x isa EXPR{Struct} || defines_mutable(x)
 defines_mutable(x) = x isa EXPR{Mutable}
 defines_abstract(x) = x isa EXPR{Abstract}
-function defines_primitive(x) 
-    x isa EXPR{Primitive} || 
+function defines_primitive(x)
+    x isa EXPR{Primitive} ||
     x isa EXPR{Bitstype} # NEEDS FIX: v0.6 dep
 end
 
@@ -253,7 +253,7 @@ end
 """
     get_sig(x)
 
-Returns the full signature of function, macro and datatype definitions. 
+Returns the full signature of function, macro and datatype definitions.
 Should only be called when has_sig(x) == true.
 """
 get_sig(x::EXPR{Struct}) = x.args[2]
@@ -307,7 +307,7 @@ end
 
 function get_name(x::BinarySyntaxOpCall)
     sig = x.arg1
-    if sig isa UnaryOpCall 
+    if sig isa UnaryOpCall
         return sig.op
     end
     sig = rem_where(sig)
@@ -349,7 +349,6 @@ function get_args(sig::EXPR{TupleH})
     end
     return args
 end
-
 
 function get_args(x::EXPR{Do})
     args = []

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -321,6 +321,10 @@ function get_args(x::IDENTIFIER)
     return []
 end
 
+function get_args(x::OPERATOR)
+    return []
+end
+
 function get_args(x)
     if defines_anon_function(x) && !(x.arg1 isa EXPR{TupleH})
         arg = x.arg1

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -92,7 +92,7 @@ end
     @test f("(a::T) -> a") == ["a"]
     @test f("(a,b) -> a") == ["a", "b"]
 
-    @test f("map(1:10) do a 
+    @test f("map(1:10) do a
         a
     end") == ["a"]
     @test f("map(1:10) do a,b

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -84,6 +84,7 @@ end
     @test f("function f(a::T,b::T) where T end") == ["a", "b"]
     @test f("function f{T}(a::T,b::T) where T end") == ["a", "b"]
     @test f("function f{T}(a::T,b::T;c = 1) where T end") == ["a", "b", "c"]
+    @test f("function(args::Vararg{Any,N}) where N end") == ["args"]
 
     @test f("a -> a") == ["a"]
     @test f("a::T -> a") == ["a"]

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -85,6 +85,7 @@ end
     @test f("function f{T}(a::T,b::T) where T end") == ["a", "b"]
     @test f("function f{T}(a::T,b::T;c = 1) where T end") == ["a", "b", "c"]
     @test f("function(args::Vararg{Any,N}) where N end") == ["args"]
+    @test f("function + end") == []
 
     @test f("a -> a") == ["a"]
     @test f("a::T -> a") == ["a"]

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -535,6 +535,7 @@ end
     @test CSTParser.parse("\"\"\" \" \"\"\"").val == " \" "
     @test CSTParser.parse("\"\"\"a\"\"\"").val == "a"
     @test CSTParser.parse("\"\"\"\"\"\"").val == ""
+    @test CSTParser.parse("\"\"\"aδ\"\"\"").val == "aδ"
     @test CSTParser.parse("\"\"\"\n\t \ta\n\n\t \tb\"\"\"").val == "a\n\nb"
     @test Expr(CSTParser.parse("\"\"\"\ta\n\tb \$c\n\td\n\"\"\"")) == Expr(:string, "\ta\n\tb ", :c, "\n\td\n")
     @test Expr(CSTParser.parse("\"\"\"\n\ta\n\tb \$c\n\td\n\"\"\"")) == Expr(:string, "\ta\n\tb ", :c, "\n\td\n")

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -255,12 +255,11 @@ end
         @test """function ()
             return
         end""" |> test_expr
+        @test """function (args::Vararg{Any,N}) where N
+            return
+        end""" |> test_expr
     end
 end
-
-
-
-
 
 @testset "Types" begin
     @testset "Abstract" begin


### PR DESCRIPTION
AbstractTrees.children is supposed to be a lazy wrapper such that
the caller can re-construct it on demand if necessary. However,
in CSTParser, it was eager, causing bad performance interactions.
This change makes Deprecations.jl 4x faster.

This also rolls up my previous commits, so it may make sense to merge them first.