### PR TITLE
Performance update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ os:
   - osx
 julia:
   - 1.0
-  - 1.0.1
 notifications:
   email: false
 # uncomment the following lines to override the default test script

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.7.0
+julia 1.0
 Tokenize 0.5.2

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,38 +1,66 @@
-using CSTParser, BenchmarkTools
+using CSTParser, BenchmarkTools, LibGit2
 
-bs = [
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("const x"))
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("return x"))
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("return"))
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("abstract type T end"))
+suite = BenchmarkGroup()
 
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("primitive type T I end"))
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("primitive"))
+suite["1arg kw"] = BenchmarkGroup()
+suite["1arg kw"]["const"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("const x"))
+suite["1arg kw"]["return"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("return x"))
+suite["1arg kw"]["return (empty)"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("return"))
 
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("import x"))
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("import x, x, x, x, x"))
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("import x.x.x.x"))
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("import x:x, x.x"))
+suite["datatypes"] = BenchmarkGroup()
+suite["datatypes"]["abstract"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("abstract type T end"))
+suite["datatypes"]["primitive"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("primitive type T I end"))
+suite["datatypes"]["struct, no sig"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("struct end"))
+suite["datatypes"]["m struct, no sig"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("mutable struct end"))
+suite["datatypes"]["struct"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("struct Name end"))
+suite["datatypes"]["m struct"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("mutable struct Name end"))
 
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("export x"))
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("export x, x, x, x, x, x"))
+suite["kw as id"] = BenchmarkGroup()
+suite["kw as id"]["abstract"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("abstract"))
+suite["kw as id"]["primitive"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("primitive"))
 
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("begin end"))
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("quote end"))
+suite["import"] = BenchmarkGroup()
+suite["import"]["single"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("import x"))
+suite["import"]["5 arg"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("import x, x, x, x, x"))
+suite["import"]["3 dots"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("import x.x.x.x"))
+suite["import"]["colon"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("import x:x, x.x"))
 
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("function end"))
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("function f end"))
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("function f() end"))
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("function f() where T where T end"))
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("for i = I end"))
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("for i = I, j = J, k = K end"))
+suite["export"] = BenchmarkGroup()
+suite["export"]["single"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("export x"))
+suite["export"]["5 arg"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("export x, x, x, x, x"))
 
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("while cond end"))
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("if cond end"))
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("""if cond
+suite["block"] = BenchmarkGroup()
+suite["block"]["begin"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("begin end"))
+suite["block"]["end"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("quote end"))
+suite["block"]["begin 5 arg"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState(
+"""
+begin 
+    var
+    var
+    var
+    var
+    var
+end"""))
+
+suite["kw function decl"] = BenchmarkGroup()
+suite["kw function decl"]["no sig"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("function end"))
+suite["kw function decl"]["sig, no call"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("function f end"))
+suite["kw function decl"]["sig, no args"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("function f() end"))
+suite["kw function decl"]["sig, no args, 2 params"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("function f() where T where T end"))
+
+suite["for"] = BenchmarkGroup()
+suite["for"]["1 iter"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("for i = I end"))
+suite["for"]["2 iter"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("for i = I, j = J, k = K end"))
+
+suite["while"] = BenchmarkGroup()
+suite["while"]["simple"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("while cond end"))
+
+suite["if"] = BenchmarkGroup()
+suite["if"]["if"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("if cond end"))
+suite["if"]["ifelse"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("""if cond
 else
 end"""))
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("""if cond
+suite["if"]["elseif *5"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("""if cond
 elseif cond
 elseif cond
 elseif cond
@@ -41,37 +69,60 @@ elseif cond
 else
 end"""))
 
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("""let x = 1
-end"""))
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("""let x = 1, y = 2, z = 3
+suite["let"] = BenchmarkGroup()
+suite["let"]["1 arg"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("let x = 1 end"))
+suite["let"]["3 arg"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("let x = 1, y = 2, z = 3 end"))
+
+suite["try"] = BenchmarkGroup()
+# suite["try"][""] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("try end"))
+suite["try"]["no cap"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("try catch end"))
+suite["try"]["cap"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("try catch e end"))
+suite["try"]["finally"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("try catch e finally end"))
+
+suite["module"] = BenchmarkGroup()
+suite["module"]["module"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("module Name end"))
+suite["module"]["baremodule"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("baremodule Name end"))
+
+suite["do"] = BenchmarkGroup()
+suite["do"]["1 arg"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("""f() do x
 end"""))
 
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("""try
-end"""))
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("""try
-catch
-end"""))
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("""try
-catch e
-end"""))
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("""try
-catch e
-finally
-end"""))
+suite["ops"] = BenchmarkGroup()
+suite["ops"]["assign * 5"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("""x=x=x=x=x"""))
+suite["ops"]["comp * 5"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("""x=>x=>x=>x=>x"""))
+suite["ops"]["cond * 5"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("""x ? x : x ? x : x ? x : x ? x : x ? x : x"""))
+suite["ops"]["bin syn * 5"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("""x||x||x||x||x"""))
+suite["ops"]["dot * 5"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("""x.x.x.x.x"""))
 
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState(""" f() do x
-end"""))
+# results = run(suite)
+# BenchmarkTools.save("bench1.ignore.json", results)
+# baseline = BenchmarkTools.load("bench1.ignore.json")
+# [leaves(minimum(baseline)) leaves(minimum(results)) leaves(ratio(minimum(baseline), minimum(results)))]
 
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("""struct
-end"""))
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("""mutable struct
-end"""))
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("""module x
-end"""))
+function compare(suite, baseline_path, save = "")
+    results = run(suite)
+    if !isempty(save)
+        BenchmarkTools.save(joinpath(@__DIR__, save), results)
+    end
+    baseline = BenchmarkTools.load(joinpath(@__DIR__, baseline_path))[1]
+    display_comp(baseline, results)
+end
 
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("""x=x=x=x=x"""))
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("""x=>x=>x=>x=>x"""))
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("""x ? x : x ? x : x ? x : x"""))
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("""x||x||x||x||x"""))
-@benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("""x.x.x.x.x"""))
-]
+function display_comp(baseline, results)
+    comp = [leaves(minimum(baseline)) leaves(minimum(results)) leaves(ratio(minimum(baseline), minimum(results)))]
+    println(rpad("name", 50), lpad("current", 15), lpad("baseline", 15), lpad("time ratio", 15), lpad("alloc ratio", 15))
+    for (n, r) in leaves(results)
+        print(rpad(join(n, "-"), 50))
+        print(lpad(BenchmarkTools.prettytime(time(r)), 15))
+        try
+            br = baseline[n]
+            print(lpad(BenchmarkTools.prettytime(time(br)), 15))
+            print(lpad(BenchmarkTools.prettypercent(ratio(time(r), time(br))), 15))
+            print(lpad(BenchmarkTools.prettypercent(ratio(allocs(r), allocs(br))), 15))
+        catch
+        end
+        println()
+    end
+end
+
+

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -9,7 +9,7 @@ suite["1arg kw"]["return (empty)"] = @benchmarkable CSTParser.parse_expression(p
 
 suite["datatypes"] = BenchmarkGroup()
 suite["datatypes"]["abstract"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("abstract type T end"))
-suite["datatypes"]["primitive"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("primitive type T I end"))
+suite["datatypes"]["primitive"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("primitive type T end"))
 suite["datatypes"]["struct, no sig"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("struct end"))
 suite["datatypes"]["m struct, no sig"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("mutable struct end"))
 suite["datatypes"]["struct"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("struct Name end"))
@@ -114,12 +114,12 @@ suite["call"]["10 kw"] = @benchmarkable CSTParser.parse_expression(ps) setup = (
 # baseline = BenchmarkTools.load("bench1.ignore.json")
 # [leaves(minimum(baseline)) leaves(minimum(results)) leaves(ratio(minimum(baseline), minimum(results)))]
 
-function compare(suite, save = "")
+function compare(suite, against = "baseline.ignore.json", save = "")
     results = run(suite)
     if !isempty(save)
         BenchmarkTools.save(joinpath(@__DIR__, save), results)
     end
-    baseline = BenchmarkTools.load(joinpath(@__DIR__, "baseline.ignore.json"))[1]
+    baseline = BenchmarkTools.load(joinpath(@__DIR__, against))[1]
     display_comp(baseline, results)
 end
 

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -13,6 +13,15 @@ suite["datatypes"]["primitive"] = @benchmarkable CSTParser.parse_expression(ps) 
 suite["datatypes"]["struct, no sig"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("struct end"))
 suite["datatypes"]["m struct, no sig"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("mutable struct end"))
 suite["datatypes"]["struct"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("struct Name end"))
+suite["datatypes"]["struct 5 args"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState(
+"""
+struct Name
+    f
+    f
+    f
+    f
+    f
+end"""))
 suite["datatypes"]["m struct"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("mutable struct Name end"))
 
 suite["kw as id"] = BenchmarkGroup()
@@ -94,17 +103,23 @@ suite["ops"]["cond * 5"] = @benchmarkable CSTParser.parse_expression(ps) setup =
 suite["ops"]["bin syn * 5"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("""x||x||x||x||x"""))
 suite["ops"]["dot * 5"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("""x.x.x.x.x"""))
 
+suite["call"] = BenchmarkGroup()
+suite["call"]["no arg"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("func()"))
+suite["call"]["1 arg"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("func(arg)"))
+suite["call"]["10 arg"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("func(arg,arg,arg,arg,arg,arg,arg,arg,arg,arg)"))
+suite["call"]["10 kw"] = @benchmarkable CSTParser.parse_expression(ps) setup = (ps = ParseState("func(arg = arg, arg = arg,arg = arg,arg = arg,arg = arg,arg = arg,arg = arg,arg = arg,arg = arg,arg = arg,)"))
+
 # results = run(suite)
 # BenchmarkTools.save("bench1.ignore.json", results)
 # baseline = BenchmarkTools.load("bench1.ignore.json")
 # [leaves(minimum(baseline)) leaves(minimum(results)) leaves(ratio(minimum(baseline), minimum(results)))]
 
-function compare(suite, baseline_path, save = "")
+function compare(suite, save = "")
     results = run(suite)
     if !isempty(save)
         BenchmarkTools.save(joinpath(@__DIR__, save), results)
     end
-    baseline = BenchmarkTools.load(joinpath(@__DIR__, baseline_path))[1]
+    baseline = BenchmarkTools.load(joinpath(@__DIR__, "baseline.ignore.json"))[1]
     display_comp(baseline, results)
 end
 

--- a/src/CSTParser.jl
+++ b/src/CSTParser.jl
@@ -84,7 +84,7 @@ function parse_compound(ps::ParseState, @nospecialize ret)
     elseif ps.nt.kind == Tokens.DO
         ret = @default ps @closer ps block parse_do(ps, ret)
     elseif isajuxtaposition(ps, ret)
-        op = OPERATOR(0, 1:0, Tokens.STAR, false)
+        op = OPERATOR(0, 0, Tokens.STAR, false)
         ret = parse_operator(ps, ret, op)
     elseif (ret isa EXPR{x_Str} ||  ret isa EXPR{x_Cmd}) && ps.nt.kind == Tokens.IDENTIFIER
         arg = IDENTIFIER(next(ps))
@@ -121,7 +121,7 @@ function parse_compound(ps::ParseState, @nospecialize ret)
     elseif ret isa UnarySyntaxOpCall && is_prime(ret.arg2)
         # prime operator followed by an identifier has an implicit multiplication
         nextarg = @precedence ps 11 parse_expression(ps)
-        ret = BinaryOpCall(ret, OPERATOR(0, 1:0, Tokens.STAR,false), nextarg)
+        ret = BinaryOpCall(ret, OPERATOR(0, 0, Tokens.STAR,false), nextarg)
 ################################################################################
 # Everything below here is an error
 ################################################################################
@@ -202,7 +202,7 @@ function parse(ps::ParseState, cont = false)
         top = EXPR{FileH}(Any[])
         if ps.nt.kind == Tokens.WHITESPACE || ps.nt.kind == Tokens.COMMENT
             next(ps)
-            push!(top, LITERAL(ps.nt.startbyte, 1:ps.nt.startbyte, "", Tokens.NOTHING))
+            push!(top, LITERAL(ps.nt.startbyte, ps.nt.startbyte, "", Tokens.NOTHING))
         end
 
         while !ps.done && !ps.errored
@@ -222,7 +222,7 @@ function parse(ps::ParseState, cont = false)
     else
         if ps.nt.kind == Tokens.WHITESPACE || ps.nt.kind == Tokens.COMMENT
             next(ps)
-            top = LITERAL(ps.nt.startbyte, 1:ps.nt.startbyte, "", Tokens.NOTHING)
+            top = LITERAL(ps.nt.startbyte, ps.nt.startbyte, "", Tokens.NOTHING)
         else
             top = parse_doc(ps)
             last_line = ps.nt.startpos[1]

--- a/src/components/keywords.jl
+++ b/src/components/keywords.jl
@@ -177,15 +177,15 @@ end
     kw = KEYWORD(ps)
     blockargs = parse_block(ps, Any[], (Tokens.END,), true)
     if isempty(blockargs)
-        block = EXPR{Block}(blockargs, 0, 1:0)
+        block = EXPR{Block}(blockargs, 0, 0)
     else
         fullspan = ps.nt.startbyte - sb - kw.fullspan
-        block = EXPR{Block}(blockargs, fullspan, 1:(fullspan - last(blockargs).fullspan + last(last(blockargs).span)))
+        block = EXPR{Block}(blockargs, fullspan, fullspan - last(blockargs).fullspan + last(blockargs).span)
     end
     # return EXPR{Begin}(Any[kw, EXPR{Block}(blockargs), accept_end(ps)])
     ender = accept_end(ps)
     fullspan1 = ps.nt.startbyte - sb
-    return EXPR{Begin}(Any[kw, block, ender], fullspan1, 1:(fullspan1 - ender.fullspan + last(ender.span)))
+    return EXPR{Begin}(Any[kw, block, ender], fullspan1, fullspan1 - ender.fullspan + ender.span)
 end
 
 @addctx :quote function parse_quote(ps::ParseState)
@@ -232,7 +232,7 @@ end
 end
 
 @addctx :macro function parse_macro(ps::ParseState)
-    sb  = ps.nt.startbyte
+    sb  = ps.t.startbyte
     kw = KEYWORD(ps)
     sig = @closer ps ws parse_expression(ps)
     sb1  = ps.nt.startbyte
@@ -240,19 +240,19 @@ end
 
     # return EXPR{Macro}(Any[kw, sig, EXPR{Block}(blockargs), accept_end(ps)])
     if isempty(blockargs)
-        block = EXPR{Block}(blockargs, 0, 1:0)
+        block = EXPR{Block}(blockargs, 0, 0)
     else
         fullspan = ps.nt.startbyte - sb1
-        block = EXPR{Block}(blockargs, fullspan, 1:(fullspan - last(blockargs).fullspan + last(last(blockargs).span)))
+        block = EXPR{Block}(blockargs, fullspan, fullspan - last(blockargs).fullspan + last(blockargs).span)
     end
     ender = accept_end(ps)
     fullspan1 = ps.nt.startbyte - sb
-    return EXPR{Macro}(Any[kw, sig, block, ender], fullspan1, 1:(fullspan1 - ender.fullspan + last(ender.span)))
+    return EXPR{Macro}(Any[kw, sig, block, ender], fullspan1, fullspan1 - ender.fullspan + ender.span)
 end
 
 # loops
 @addctx :for function parse_for(ps::ParseState)
-    sb  = ps.nt.startbyte
+    sb  = ps.t.startbyte
     kw = KEYWORD(ps)
     ranges = parse_ranges(ps)
     sb1  = ps.nt.startbyte
@@ -260,18 +260,18 @@ end
 
     # return EXPR{For}(Any[kw, ranges, EXPR{Block}(blockargs), accept_end(ps)])
     if isempty(blockargs)
-        block = EXPR{Block}(blockargs, 0, 1:0)
+        block = EXPR{Block}(blockargs, 0, 0)
     else
         fullspan = ps.nt.startbyte - sb1
-        block = EXPR{Block}(blockargs, fullspan, 1:(fullspan - last(blockargs).fullspan + last(last(blockargs).span)))
+        block = EXPR{Block}(blockargs, fullspan, fullspan - last(blockargs).fullspan + last(blockargs).span)
     end
     ender = accept_end(ps)
     fullspan1 = ps.nt.startbyte - sb
-    return EXPR{Macro}(Any[kw, ranges, block, ender], fullspan1, 1:(fullspan1 - ender.fullspan + last(ender.span)))
+    return EXPR{For}(Any[kw, ranges, block, ender], fullspan1, fullspan1 - ender.fullspan + ender.span)
 end
 
 @addctx :while function parse_while(ps::ParseState)
-    sb = ps.nt.startbyte
+    sb = ps.t.startbyte
     kw = KEYWORD(ps)
     cond = @closer ps ws parse_expression(ps)
     sb1 = ps.nt.startbyte
@@ -279,14 +279,14 @@ end
 
     # return EXPR{While}(Any[kw, cond, EXPR{Block}(blockargs), accept_end(ps)])
     if isempty(blockargs)
-        block = EXPR{Block}(blockargs, 0, 1:0)
+        block = EXPR{Block}(blockargs, 0, 0)
     else
         fullspan = ps.nt.startbyte - sb1
-        block = EXPR{Block}(blockargs, fullspan, 1:(fullspan - last(blockargs).fullspan + last(last(blockargs).span)))
+        block = EXPR{Block}(blockargs, fullspan, fullspan - last(blockargs).fullspan + last(blockargs).span)
     end
     ender = accept_end(ps)
     fullspan1 = ps.nt.startbyte - sb
-    return EXPR{While}(Any[kw, cond, block, ender], fullspan1, 1:(fullspan1 - ender.fullspan + last(ender.span)))
+    return EXPR{While}(Any[kw, cond, block, ender], fullspan1, fullspan1 - ender.fullspan + ender.span)
 end
 
 # control flow
@@ -426,7 +426,7 @@ end
 # modules
 
 @addctx :module function parse_module(ps::ParseState)
-    sb = ps.nt.startbyte
+    sb = ps.t.startbyte
     kw = KEYWORD(ps)
     @assert kw.kind == Tokens.MODULE || kw.kind == Tokens.BAREMODULE # work around julia issue #23766
     if ps.nt.kind == Tokens.IDENTIFIER
@@ -441,14 +441,14 @@ end
 
     # return EXPR{(is_module(kw) ? ModuleH : BareModule)}(Any[kw, arg, block, accept_end(ps)])
     if isempty(blockargs)
-        block = EXPR{Block}(blockargs, 0, 1:0)
+        block = EXPR{Block}(blockargs, 0, 0)
     else
         fullspan = ps.nt.startbyte - sb1
-        block = EXPR{Block}(blockargs, fullspan, 1:(fullspan - last(blockargs).fullspan + last(last(blockargs).span)))
+        block = EXPR{Block}(blockargs, fullspan, fullspan - last(blockargs).fullspan + last(blockargs).span)
     end
     ender = accept_end(ps)
     fullspan1 = ps.nt.startbyte - sb
-    return EXPR{(is_module(kw) ? ModuleH : BareModule)}(Any[kw, arg, block, ender], fullspan1, 1:(fullspan1 - ender.fullspan + last(ender.span)))
+    return EXPR{(is_module(kw) ? ModuleH : BareModule)}(Any[kw, arg, block, ender], fullspan1, fullspan1 - ender.fullspan + ender.span)
 end
 
 
@@ -467,7 +467,7 @@ end
 
 
 @addctx :struct function parse_struct(ps::ParseState, mutable)
-    sb = ps.nt.startbyte
+    sb = ps.t.startbyte
     kw = KEYWORD(ps)
     sig = @closer ps ws parse_expression(ps)    
     sb1 = ps.nt.startbyte
@@ -475,12 +475,12 @@ end
     
     # return EXPR{mutable ? Mutable : Struct}(Any[kw, sig, EXPR{Block}(blockargs), accept_end(ps)])
     if isempty(blockargs)
-        block = EXPR{Block}(blockargs, 0, 1:0)
+        block = EXPR{Block}(blockargs, 0, 0)
     else
         fullspan = ps.nt.startbyte - sb1
-        block = EXPR{Block}(blockargs, fullspan, 1:(fullspan - last(blockargs).fullspan + last(last(blockargs).span)))
+        block = EXPR{Block}(blockargs, fullspan, fullspan - last(blockargs).fullspan + last(blockargs).span)
     end
     ender = accept_end(ps)
     fullspan1 = ps.nt.startbyte - sb
-    return EXPR{mutable ? Mutable : Struct}(Any[kw, sig, block, ender], fullspan1, 1:(fullspan1 - ender.fullspan + last(ender.span)))
+    return EXPR{mutable ? Mutable : Struct}(Any[kw, sig, block, ender], fullspan1, fullspan1 - ender.fullspan + ender.span)
 end

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -204,6 +204,8 @@ end
 function Expr(x::EXPR{MacroName})
     if x.args[2] isa IDENTIFIER
         return Symbol("@", x.args[2].val)
+    else
+        return Symbol("@")
     end
 end
 
@@ -815,7 +817,7 @@ function Expr(x::EXPR{StringH})
     ret
 end
 
-UNICODE_OPS_REVERSE = Dict{Tokenize.Tokens.Kind,Symbol}()
+const UNICODE_OPS_REVERSE = Dict{Tokenize.Tokens.Kind,Symbol}()
 for (k, v) in Tokenize.Tokens.UNICODE_OPS
     UNICODE_OPS_REVERSE[v] = Symbol(k)
 end

--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -80,7 +80,9 @@ function next(ps::ParseState)
         ps.nnt = ps.nt
         ps.done = ps.done
     else
-        ps.nnt, ps.done  = iterate(ps.l, ps.done)
+        ps.nnt = Tokenize.Lexers.next_token(ps.l)
+        ps.done = ps.nnt == Tokens.ENDMARKER
+        # ps.nnt, ps.done  = iterate(ps.l, ps.done)
     end
     
     # combines whitespace, comments and semicolons

--- a/src/recovery.jl
+++ b/src/recovery.jl
@@ -21,7 +21,7 @@ function accept_rparen(ps)
         return PUNCTUATION(next(ps))
     else
         push!(ps.errors, Error((ps.ws.startbyte:ps.ws.endbyte) .+ 1 , "Expected )."))
-        return ErrorToken(PUNCTUATION(Tokens.RPAREN, 0, 1:0))
+        return ErrorToken(PUNCTUATION(Tokens.RPAREN, 0, 0))
     end
 end
 accept_rparen(ps::ParseState, args) = push!(args, accept_rparen(ps))
@@ -31,7 +31,7 @@ function accept_rsquare(ps)
         return PUNCTUATION(next(ps))
     else
         push!(ps.errors, Error((ps.t.startbyte:ps.t.endbyte) .+ 1 , "Expected ]."))
-        return ErrorToken(PUNCTUATION(Tokens.RSQUARE, 0, 1:0))
+        return ErrorToken(PUNCTUATION(Tokens.RSQUARE, 0, 0))
     end
 end
 accept_rsquare(ps::ParseState, args) = push!(args, accept_rsquare(ps))
@@ -41,7 +41,7 @@ function accept_rbrace(ps)
         return PUNCTUATION(next(ps))
     else
         push!(ps.errors, Error((ps.t.startbyte:ps.t.endbyte) .+ 1 , "Expected }."))
-        return ErrorToken(PUNCTUATION(Tokens.RBRACE, 0, 1:0))
+        return ErrorToken(PUNCTUATION(Tokens.RBRACE, 0, 0))
     end
 end
 accept_rbrace(ps::ParseState, args) = push!(args, accept_rbrace(ps))
@@ -51,7 +51,7 @@ function accept_end(ps::ParseState)
         return KEYWORD(next(ps))
     else
         push!(ps.errors, Error((ps.t.startbyte:ps.t.endbyte) .+ 1 , "Expected end."))
-        return ErrorToken(KEYWORD(Tokens.END, 0, 1:0))
+        return ErrorToken(KEYWORD(Tokens.END, 0, 0))
     end
 end
 accept_end(ps::ParseState, args) = push!(args, accept_end(ps))
@@ -60,7 +60,7 @@ function accept_comma(ps)
     if ps.nt.kind == Tokens.COMMA
         return PUNCTUATION(next(ps))
     else
-        return PUNCTUATION(Tokens.RPAREN, 0, 1:0)
+        return PUNCTUATION(Tokens.RPAREN, 0, 0)
     end
 end
 accept_comma(ps::ParseState, args) = push!(args, accept_comma(ps))
@@ -70,13 +70,13 @@ function recover_endmarker(ps)
         if !isempty(ps.closer.cc)
             closert = last(ps.closer.cc)
             if closert == :block
-                return ErrorToken(KEYWORD(Tokens.END, 0, 1:0))
+                return ErrorToken(KEYWORD(Tokens.END, 0, 0))
             elseif closert == :paren
-                return ErrorToken(PUNCTUATION(Tokens.RPAREN, 0, 1:0))
+                return ErrorToken(PUNCTUATION(Tokens.RPAREN, 0, 0))
             elseif closert == :square
-                return ErrorToken(PUNCTUATION(Tokens.RSQUARE, 0, 1:0))
+                return ErrorToken(PUNCTUATION(Tokens.RSQUARE, 0, 0))
             elseif closert == :brace
-                return ErrorToken(PUNCTUATION(Tokens.RBRACE, 0, 1:0))
+                return ErrorToken(PUNCTUATION(Tokens.RBRACE, 0, 0))
             end
         end
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -592,7 +592,7 @@ end
 
 
 function trailing_ws_length(x)
-    x.fullspan - length(x.span)
+    x.fullspan - x.span
 end
 
 

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -336,8 +336,7 @@ end
     @test "Int[(y,x) for y in X]" |> test_expr
     @test """
     [a
-    for a = 1:2]
-    """ |> test_expr
+    for a = 1:2]""" |> test_expr
     @test "[ V[j][i]::T for i=1:length(V[1]), j=1:length(V) ]" |> test_expr
     @test "all(d ≥ 0 for d in B.dims)" |> test_expr
     @test "(arg for x in X)" |> test_expr

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -20,7 +20,7 @@ function test_expr(str, show_data = true)
     x, ps = CSTParser.parse(ParseState(str))
 
     x0 = Expr(x)
-    x1 = remlineinfo!(flisp_parse(str))
+    x1 = remlineinfo!(Meta.parse(str))
     if ps.errored || x0 != x1
         if show_data
             println("Mismatch between flisp and CSTParser when parsing string $str")

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -35,6 +35,7 @@ function test_expr(str, show_data = true)
 end
 
 @testset "All tests" begin
+@test Meta.parse("1,") == Expr(:tuple, 1)
 @testset "Operators" begin
     # @testset "Binary Operators" begin
     #     for iter = 1:25


### PR DESCRIPTION
Some low-hanging performance fixes, gives a ~ 2x speedup. 

One internal changes, the `.span` field is now an `Int` rather than `UnitRange{Int}`. Previously the `start` was always `1` and so was redundant. Will require changes made to StaticLint, LanguageServer and DocumentFormat