### PR TITLE
fix parsing of at-cmd for julia 1.1

### DIFF
--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -215,8 +215,13 @@ function Expr(x::EXPR{MacroName})
 end
 
 # cross compatability for line number insertion in macrocalls
+if VERSION > v"1.1-"
+Expr_cmd(x) = Expr(:macrocall, GlobalRef(Core, Symbol("@cmd")), nothing, x.val)
+Expr_tcmd(x) = Expr(:macrocall, GlobalRef(Core, Symbol("@cmd")), nothing, x.val)
+else
 Expr_cmd(x) = Expr(:macrocall, Symbol("@cmd"), nothing, x.val)
 Expr_tcmd(x) = Expr(:macrocall, Symbol("@cmd"), nothing, x.val)
+end
 
 function Expr(x::EXPR{x_Str})
     if x.args[1] isa BinarySyntaxOpCall


### PR DESCRIPTION
This fixes one changed parsing in julia 1.1.

The other needed change is that `x,` is now considered incomplete input unless followed by `=`. I'm not sure how to implement that here yet.