### PR TITLE
Refactor

### DIFF
--- a/src/CSTParser.jl
+++ b/src/CSTParser.jl
@@ -126,7 +126,7 @@ function parse_compound(ps::ParseState, @nospecialize ret)
     elseif isoperator(ps.nt)
         op = mOPERATOR(next(ps))
         ret = parse_operator(ps, ret, op)
-    elseif ret.typ === UnaryOpCall && is_prime(ret.arg2)
+    elseif ret.typ === UnaryOpCall && is_prime(ret.args[2])
         # prime operator followed by an identifier has an implicit multiplication
         nextarg = @precedence ps 11 parse_expression(ps)
         ret = mBinaryOpCall(ret, mOPERATOR(0, 0, Tokens.STAR,false), nextarg)

--- a/src/CSTParser.jl
+++ b/src/CSTParser.jl
@@ -76,7 +76,6 @@ function parse_expression(ps::ParseState)
             ps.errored = true
             ret = mErrorToken(INSTANCE(ps), UnexpectedToken)
         end
-
         while !closer(ps)
             ret = parse_compound(ps, ret)
         end
@@ -92,7 +91,7 @@ function parse_compound(ps::ParseState, @nospecialize ret)
     elseif isajuxtaposition(ps, ret)
         if is_number(ret) && last(ret.val) == '.'
             ps.errored = true
-            ret = mErrorToken(ret)
+            ret = mErrorToken(ret, CannotJuxtapose)
         end
         op = mOPERATOR(0, 0, Tokens.STAR, false)
         ret = parse_operator(ps, ret, op)
@@ -138,7 +137,7 @@ function parse_compound(ps::ParseState, @nospecialize ret)
 ################################################################################
     elseif ps.nt.kind in (Tokens.RPAREN, Tokens.RSQUARE, Tokens.RBRACE)
         ps.errored = true
-        ret = EXPR(ErrorToken, EXPR[ret, mErrorToken(mPUNCTUATION(next(ps)))])
+        ret = EXPR(ErrorToken, EXPR[ret, mErrorToken(mPUNCTUATION(next(ps)), Unknown)])
     else
         nextarg = parse_expression(ps)
         ps.errored = true
@@ -216,7 +215,7 @@ function parse(ps::ParseState, cont = false)
             push!(top, mLITERAL(ps.nt.startbyte, ps.nt.startbyte, "", Tokens.NOTHING))
         end
 
-        while !ps.done && !ps.errored
+        while !ps.done
             curr_line = ps.nt.startpos[1]
             ret = parse_doc(ps)
 

--- a/src/CSTParser.jl
+++ b/src/CSTParser.jl
@@ -84,6 +84,9 @@ function parse_compound(ps::ParseState, @nospecialize ret)
     elseif ps.nt.kind == Tokens.DO
         ret = @default ps @closer ps block parse_do(ps, ret)
     elseif isajuxtaposition(ps, ret)
+        if is_number(ret) && last(ret.val) == '.'
+            ret = mErrorToken(ret)
+        end
         op = mOPERATOR(0, 0, Tokens.STAR, false)
         ret = parse_operator(ps, ret, op)
     elseif (ret.typ === x_Str ||  ret.typ === x_Cmd) && ps.nt.kind == Tokens.IDENTIFIER

--- a/src/components/internals.jl
+++ b/src/components/internals.jl
@@ -125,7 +125,7 @@ function parse_call(ps::ParseState, ret, ismacro = false)
         end
     elseif is_and(ret) || is_decl(ret) || is_exor(ret) 
         arg = @precedence ps 20 parse_expression(ps)
-        if is_exor(ret) && arg.typ === TupleH && length(arg.args) == 3 && arg.args[2].typ === UnaryOpCall && is_dddot(arg.args[2].arg2)
+        if is_exor(ret) && arg.typ === TupleH && length(arg.args) == 3 && arg.args[2].typ === UnaryOpCall && is_dddot(arg.args[2].arg[2])
             arg = EXPR(InvisBrackets, arg.args)
         end
         ret = mUnaryOpCall(ret, arg)
@@ -269,7 +269,7 @@ function parse_generator(ps::ParseState, @nospecialize ret)
         ret = EXPR(Flatten, EXPR[ret])
     end
 
-    return newscope!(ret)
+    return setscope!(ret)
 end
 
 

--- a/src/components/internals.jl
+++ b/src/components/internals.jl
@@ -1,7 +1,7 @@
 const term_c = (Tokens.RPAREN, Tokens.RSQUARE, Tokens.RBRACE, Tokens.END, Tokens.ELSE, Tokens.ELSEIF, Tokens.CATCH, Tokens.FINALLY, Tokens.ENDMARKER)
 
 function parse_block(ps::ParseState, ret::Vector{EXPR} = EXPR[], closers = (Tokens.END,), docable = false)
-    while ps.nt.kind ∉ closers && !ps.errored
+    while ps.nt.kind ∉ closers
         if ps.nt.kind ∈ term_c
             if ps.nt.kind == Tokens.ENDMARKER
                 break
@@ -111,7 +111,6 @@ function parse_call(ps::ParseState, ret, ismacro = false)
     elseif ret.typ === Curly && ret.args[1].val == "new" && :struct in ps.closer.cc
         ret.args[1] = setparent!(mKEYWORD(Tokens.NEW, ret.args[1].fullspan, ret.args[1].span), ret)
     end
-    # ret = requires_no_ws(ret)
     if is_minus(ret) || is_not(ret)
         arg = @closer ps unary @closer ps inwhere @precedence ps 13 parse_expression(ps)
         if arg.typ === TupleH

--- a/src/components/internals.jl
+++ b/src/components/internals.jl
@@ -122,6 +122,7 @@ function parse_call(ps::ParseState, ret, ismacro = false)
     elseif ret.typ === Curly && ret.args[1].val == "new" && :struct in ps.closer.cc
         ret.args[1] = setparent!(mKEYWORD(Tokens.NEW, ret.args[1].fullspan, ret.args[1].span), ret)
     end
+    # ret = requires_no_ws(ret)
     if is_minus(ret) || is_not(ret)
         arg = @closer ps unary @closer ps inwhere @precedence ps 13 parse_expression(ps)
         if arg.typ === TupleH

--- a/src/components/internals.jl
+++ b/src/components/internals.jl
@@ -99,17 +99,6 @@ function is_range(x)
     x.typ === BinaryOpCall && (is_eq(x.args[2]) || is_in(x.args[2]) || is_elof(x.args[2]))
 end
 
-function parse_end(ps::ParseState)
-    if ps.closer.square
-        ret = mKEYWORD(ps)
-    else
-        push!(ps.errors, Error((ps.t.startbyte:ps.t.endbyte) .+ 1 , "Unexpected end."))
-        ret = mErrorToken(mIDENTIFIER(ps))
-    end
-    
-    return ret
-end
-
 """
     parse_call(ps, ret)
 

--- a/src/components/keywords.jl
+++ b/src/components/keywords.jl
@@ -79,7 +79,12 @@ function parse_const(ps::ParseState)
         ps.errored = true
         arg = mErrorToken(arg, ExpectedAssignment)
     end
-    return EXPR(Const, EXPR[kw, arg])
+    ret = EXPR(Const, EXPR[kw, arg])
+    if arg.typ === BinaryOpCall && arg.args[2].kind === Tokens.EQ && arg.args[1].typ === Curly
+        #setbinding!
+        mark_typealias_bindings!(arg)
+    end
+    return ret
 end
 
 function parse_global(ps::ParseState)

--- a/src/components/keywords.jl
+++ b/src/components/keywords.jl
@@ -42,7 +42,14 @@ function parse_kw(ps)
     elseif k == Tokens.RETURN
         return @default ps parse_return(ps)
     elseif k == Tokens.END
-        return parse_end(ps)
+        if ps.closer.square
+            ret = mKEYWORD(ps)
+        else
+            push!(ps.errors, Error((ps.t.startbyte:ps.t.endbyte) .+ 1 , "Unexpected end."))
+            ret = mErrorToken(mIDENTIFIER(ps))
+        end
+        
+        return ret
     elseif k == Tokens.ELSE || k == Tokens.ELSEIF || k == Tokens.CATCH || k == Tokens.FINALLY
         push!(ps.errors, Error((ps.t.startbyte:ps.t.endbyte) .+ 1 , "Unexpected end."))
         return mErrorToken(mIDENTIFIER(ps))

--- a/src/components/keywords.jl
+++ b/src/components/keywords.jl
@@ -473,7 +473,7 @@ end
     end
     ender = accept_end(ps)
     fullspan1 = ps.nt.startbyte - sb
-    return setscope!(EXPR(is_module(kw) ? ModuleH : BareModule, EXPR[kw, arg, block, ender], fullspan1, fullspan1 - ender.fullspan + ender.span))
+    return setscope!(EXPR(is_module(kw) ? ModuleH : BareModule, EXPR[kw, arg, block, ender], fullspan1, fullspan1 - ender.fullspan + ender.span), Scope(nothing, Dict{String,Binding}(), nothing, true))
 end
 
 

--- a/src/components/keywords.jl
+++ b/src/components/keywords.jl
@@ -67,7 +67,9 @@ end
 function parse_const(ps::ParseState)
     kw = mKEYWORD(ps)
     arg = parse_expression(ps)
-
+    if arg.typ !== BinaryOpCall || arg.args[2].kind !== Tokens.EQ
+        arg = mErrorToken(arg)
+    end
     return EXPR(Const, EXPR[kw, arg])
 end
 

--- a/src/components/lists.jl
+++ b/src/components/lists.jl
@@ -13,7 +13,8 @@ function parse_tuple end
             if (isassignment(ps.nt) && ps.nt.kind != Tokens.APPROX)
                 push!(ret, op)
             elseif closer(ps)
-                push!(ret, mErrorToken(op))
+                ps.errored = true
+                push!(ret, mErrorToken(op, Unknown))
             else
                 nextarg = @closer ps tuple parse_expression(ps)
                 if !(is_lparen(first(ret.args)))
@@ -27,7 +28,8 @@ function parse_tuple end
             if (isassignment(ps.nt) && ps.nt.kind != Tokens.APPROX)
                 ret = EXPR(TupleH, EXPR[ret, op])
             elseif closer(ps)
-                ret = mErrorToken(EXPR(TupleH, EXPR[ret, op]))
+                ps.errored = true
+                ret = mErrorToken(EXPR(TupleH, EXPR[ret, op]), Unknown)
             else
                 nextarg = @closer ps tuple parse_expression(ps)
                 ret = EXPR(TupleH, EXPR[ret, op, nextarg])

--- a/src/components/lists.jl
+++ b/src/components/lists.jl
@@ -8,12 +8,12 @@ function parse_tuple end
 
 @static if VERSION > v"1.1-"
     function parse_tuple(ps::ParseState, @nospecialize(ret))
-        op = PUNCTUATION(next(ps))
+        op = mPUNCTUATION(next(ps))
         if ret.typ == TupleH
             if (isassignment(ps.nt) && ps.nt.kind != Tokens.APPROX)
                 push!(ret, op)
             elseif closer(ps)
-                push!(ret, ErrorToken(op))
+                push!(ret, mErrorToken(op))
             else
                 nextarg = @closer ps tuple parse_expression(ps)
                 if !(is_lparen(first(ret.args)))
@@ -27,7 +27,7 @@ function parse_tuple end
             if (isassignment(ps.nt) && ps.nt.kind != Tokens.APPROX)
                 ret = EXPR(TupleH, EXPR[ret, op])
             elseif closer(ps)
-                ret = ErrorToken(EXPR(TupleH, EXPR[ret, op]))
+                ret = mErrorToken(EXPR(TupleH, EXPR[ret, op]))
             else
                 nextarg = @closer ps tuple parse_expression(ps)
                 ret = EXPR(TupleH, EXPR[ret, op, nextarg])
@@ -37,7 +37,7 @@ function parse_tuple end
     end
 else
     function parse_tuple(ps::ParseState, @nospecialize(ret))
-        op = PUNCTUATION(next(ps))
+        op = mPUNCTUATION(next(ps))
         if x.typ === TupleH
             if closer(ps) || (isassignment(ps.nt) && ps.nt.kind != Tokens.APPROX)
                 push!(ret, op)
@@ -72,7 +72,7 @@ Having hit '[' return either:
 + An array (vcat of hcats)
 """
 function parse_array(ps::ParseState)
-    args = EXPR[PUNCTUATION(ps)]
+    args = EXPR[mPUNCTUATION(ps)]
 
     if ps.nt.kind == Tokens.RSQUARE
         accept_rsquare(ps, args)
@@ -221,14 +221,14 @@ Parses the juxtaposition of `ret` with an opening brace. Parses a comma
 seperated list.
 """
 function parse_curly(ps::ParseState, ret)
-    args = EXPR[ret, PUNCTUATION(next(ps))]
+    args = EXPR[ret, mPUNCTUATION(next(ps))]
     parse_comma_sep(ps, args, true)
     accept_rbrace(ps, args)
     return EXPR(Curly, args)
 end
 
 function parse_braces(ps::ParseState)
-    args = EXPR[PUNCTUATION(ps)]
+    args = EXPR[mPUNCTUATION(ps)]
     parse_comma_sep(ps, args, true)
     accept_rbrace(ps, args)
     return EXPR(Braces, args)

--- a/src/components/lists.jl
+++ b/src/components/lists.jl
@@ -40,7 +40,7 @@ function parse_tuple end
 else
     function parse_tuple(ps::ParseState, @nospecialize(ret))
         op = mPUNCTUATION(next(ps))
-        if x.typ === TupleH
+        if ret.typ === TupleH
             if closer(ps) || (isassignment(ps.nt) && ps.nt.kind != Tokens.APPROX)
                 push!(ret, op)
             else

--- a/src/components/lists.jl
+++ b/src/components/lists.jl
@@ -9,31 +9,28 @@ function parse_tuple end
 @static if VERSION > v"1.1-"
     function parse_tuple(ps::ParseState, @nospecialize(ret))
         op = PUNCTUATION(next(ps))
-        if (isassignment(ps.nt) && ps.nt.kind != Tokens.APPROX)
-            ret = EXPR{TupleH}(Any[ret, op])
-        elseif closer(ps)
-            ret = ErrorToken(EXPR{TupleH}(Any[ret, op]))
-        else
-            nextarg = @closer ps tuple parse_expression(ps)
-            ret = EXPR{TupleH}(Any[ret, op, nextarg])
-        end
-        return ret
-    end
-    
-    function parse_tuple(ps::ParseState, ret::EXPR{TupleH})
-        op = PUNCTUATION(next(ps))
-        if (isassignment(ps.nt) && ps.nt.kind != Tokens.APPROX)
-            push!(ret, op)
-        elseif closer(ps)
-            push!(ret, op)
-            ret = ErrorToken(ret)
-        else
-            nextarg = @closer ps tuple parse_expression(ps)
-            if !(is_lparen(first(ret.args)))
+        if ret.typ == TupleH
+            if (isassignment(ps.nt) && ps.nt.kind != Tokens.APPROX)
                 push!(ret, op)
-                push!(ret, nextarg)
+            elseif closer(ps)
+                push!(ret, ErrorToken(op))
             else
-                ret = EXPR{TupleH}(Any[ret, op, nextarg])
+                nextarg = @closer ps tuple parse_expression(ps)
+                if !(is_lparen(first(ret.args)))
+                    push!(ret, op)
+                    push!(ret, nextarg)
+                else
+                    ret = EXPR(TupleH, EXPR[ret, op, nextarg])
+                end
+            end
+        else
+            if (isassignment(ps.nt) && ps.nt.kind != Tokens.APPROX)
+                ret = EXPR(TupleH, EXPR[ret, op])
+            elseif closer(ps)
+                ret = ErrorToken(EXPR(TupleH, EXPR[ret, op]))
+            else
+                nextarg = @closer ps tuple parse_expression(ps)
+                ret = EXPR(TupleH, EXPR[ret, op, nextarg])
             end
         end
         return ret
@@ -41,30 +38,29 @@ function parse_tuple end
 else
     function parse_tuple(ps::ParseState, @nospecialize(ret))
         op = PUNCTUATION(next(ps))
-        if closer(ps) || (isassignment(ps.nt) && ps.nt.kind != Tokens.APPROX)
-            ret = EXPR{TupleH}(Any[ret, op])
-        else
-            nextarg = @closer ps tuple parse_expression(ps)
-            ret = EXPR{TupleH}(Any[ret, op, nextarg])
-        end
-        return ret
-    end
-    
-    function parse_tuple(ps::ParseState, ret::EXPR{TupleH})
-        op = PUNCTUATION(next(ps))
-        if closer(ps) || (isassignment(ps.nt) && ps.nt.kind != Tokens.APPROX)
-            push!(ret, op)
-        else
-            nextarg = @closer ps tuple parse_expression(ps)
-            if !(is_lparen(first(ret.args)))
+        if x.typ === TupleH
+            if closer(ps) || (isassignment(ps.nt) && ps.nt.kind != Tokens.APPROX)
                 push!(ret, op)
-                push!(ret, nextarg)
             else
-                ret = EXPR{TupleH}(Any[ret, op, nextarg])
+                nextarg = @closer ps tuple parse_expression(ps)
+                if !(is_lparen(first(ret.args)))
+                    push!(ret, op)
+                    push!(ret, nextarg)
+                else
+                    ret = EXPR(TupleH, EXPR[ret, op, nextarg])
+                end
+            end
+        else
+            if closer(ps) || (isassignment(ps.nt) && ps.nt.kind != Tokens.APPROX)
+                ret = EXPR(TupleH, EXPR[ret, op])
+            else
+                nextarg = @closer ps tuple parse_expression(ps)
+                ret = EXPR(TupleH, EXPR[ret, op, nextarg])
             end
         end
         return ret
     end
+    
 end
 
 """
@@ -76,31 +72,31 @@ Having hit '[' return either:
 + An array (vcat of hcats)
 """
 function parse_array(ps::ParseState)
-    args = Any[PUNCTUATION(ps)]
+    args = EXPR[PUNCTUATION(ps)]
 
     if ps.nt.kind == Tokens.RSQUARE
         accept_rsquare(ps, args)
-        ret = EXPR{Vect}(args)
+        ret = EXPR(Vect, args)
     else
         first_arg = @nocloser ps newline @closesquare ps  @closer ps insquare @closer ps ws @closer ps wsop @closer ps comma parse_expression(ps)
 
         if ps.nt.kind == Tokens.RSQUARE
-            if first_arg isa EXPR{Generator} || first_arg isa EXPR{Flatten}
+            if first_arg.typ === Generator || first_arg.typ === Flatten
                 accept_rsquare(ps, args)
 
-                if first_arg.args[1] isa BinaryOpCall && is_pairarrow(first_arg.args[1].op)
-                    return EXPR{DictComprehension}(Any[args[1], first_arg, INSTANCE(ps)])
+                if first_arg.args[1].typ === BinaryOpCall && is_pairarrow(first_arg.args[1].args[2])
+                    return EXPR(DictComprehension,EXPR[args[1], first_arg, INSTANCE(ps)])
                 else
-                    return EXPR{Comprehension}(Any[args[1], first_arg, INSTANCE(ps)])
+                    return EXPR(Comprehension, EXPR[args[1], first_arg, INSTANCE(ps)])
                 end
             elseif ps.ws.kind == SemiColonWS
                 push!(args, first_arg)
                 accept_rsquare(ps, args)
-                return EXPR{Vcat}(args)
+                return EXPR(Vcat, args)
             else
                 push!(args, first_arg)
                 accept_rsquare(ps, args)
-                ret = EXPR{Vect}(args)
+                ret = EXPR(Vect, args)
             end
         elseif ps.nt.kind == Tokens.COMMA
             etype = Vect
@@ -108,9 +104,9 @@ function parse_array(ps::ParseState)
             accept_comma(ps, args)
             @closesquare ps parse_comma_sep(ps, args, false)
             accept_rsquare(ps, args)
-            return EXPR{etype}(args)
+            return EXPR(etype, args)
         elseif ps.ws.kind == NewLineWS
-            ret = EXPR{Vcat}(args)
+            ret = EXPR(Vcat, args)
             push!(ret, first_arg)
             while ps.nt.kind != Tokens.RSQUARE
                 if ps.nt.kind == Tokens.ENDMARKER
@@ -123,7 +119,7 @@ function parse_array(ps::ParseState)
             update_span!(ret)
             return ret
         elseif ps.ws.kind == WS || ps.ws.kind == SemiColonWS
-            first_row = EXPR{Hcat}(Any[first_arg])
+            first_row = EXPR(Hcat, EXPR[first_arg])
             while ps.nt.kind != Tokens.RSQUARE && ps.ws.kind != NewLineWS && ps.ws.kind != SemiColonWS
                 if ps.nt.kind == Tokens.ENDMARKER
                     break
@@ -133,7 +129,7 @@ function parse_array(ps::ParseState)
             end
             if ps.nt.kind == Tokens.RSQUARE && ps.ws.kind != SemiColonWS
                 if length(first_row.args) == 1
-                    first_row = EXPR{Vcat}(first_row.args)
+                    first_row = EXPR(Vcat, first_row.args)
                 end
                 push!(first_row, INSTANCE(next(ps)))
                 pushfirst!(first_row, args[1])
@@ -143,15 +139,15 @@ function parse_array(ps::ParseState)
                 if length(first_row.args) == 1
                     first_row = first_row.args[1]
                 else
-                    first_row = EXPR{Row}(first_row.args)
+                    first_row = EXPR(Row, first_row.args)
                 end
-                ret = EXPR{Vcat}(Any[args[1], first_row])
+                ret = EXPR(Vcat, EXPR[args[1], first_row])
                 while ps.nt.kind != Tokens.RSQUARE
                     if ps.nt.kind == Tokens.ENDMARKER
                         break
                     end
                     first_arg = @closesquare ps @closer ps ws @closer ps wsop parse_expression(ps)
-                    push!(ret, EXPR{Row}(Any[first_arg]))
+                    push!(ret, EXPR(Row, EXPR[first_arg]))
                     while ps.nt.kind != Tokens.RSQUARE && ps.ws.kind != NewLineWS && ps.ws.kind != SemiColonWS
                         if ps.nt.kind == Tokens.ENDMARKER
                             break
@@ -161,7 +157,7 @@ function parse_array(ps::ParseState)
                     end
                     # if only one entry dont use :row
                     if length(last(ret.args).args) == 1
-                        ret.args[end] = ret.args[end].args[1]
+                        ret.args[end] = setparent!(ret.args[end].args[1], ret)
                     end
                     update_span!(ret)
                 end
@@ -170,7 +166,7 @@ function parse_array(ps::ParseState)
                 return ret
             end
         else
-            ret = EXPR{Vect}(args)
+            ret = EXPR(Vect, args)
             push!(ret, first_arg)
             push!(ret, accept_rsquare(ps))
         end
@@ -185,43 +181,38 @@ Handles cases where an expression - `ret` - is followed by
 `[`. Parses the following bracketed expression and modifies it's
 `.head` appropriately.
 """
-function parse_ref(ps::ParseState, ret)
+function parse_ref(ps::ParseState, @nospecialize(ret))
     next(ps)
     ref = parse_array(ps)
-    return _parse_ref(ret, ref)
+    if ref.typ === Vect
+        args = EXPR[ret]
+        for a in ref.args
+            push!(args, a)
+        end
+        return EXPR(Ref, args)
+    elseif ref.typ === Hcat
+        args = EXPR[ret]
+        for a in ref.args
+            push!(args, a)
+        end
+        return EXPR(TypedHcat ,args)
+    elseif ref.typ === Vcat
+        args = EXPR[ret]
+        for a in ref.args
+            push!(args, a)
+        end
+        return EXPR(TypedVcat, args)
+    else
+        args = EXPR[ret]
+        for a in ref.args
+            push!(args, a)
+        end
+        return EXPR(TypedComprehension, args)
+    end
 end
 
-function _parse_ref(ret, ref::EXPR{Vect})
-    args = Any[ret]
-    for a in ref.args
-        push!(args, a)
-    end
-    return EXPR{Ref}(args)
-end
 
-function _parse_ref(ret, ref::EXPR{Hcat})
-    args = Any[ret]
-    for a in ref.args
-        push!(args, a)
-    end
-    return EXPR{TypedHcat}(args)
-end
 
-function _parse_ref(ret, ref::EXPR{Vcat})
-    args = Any[ret]
-    for a in ref.args
-        push!(args, a)
-    end
-    return EXPR{TypedVcat}(args)
-end
-
-function _parse_ref(ret, ref)
-    args = Any[ret]
-    for a in ref.args
-        push!(args, a)
-    end
-    return EXPR{TypedComprehension}(args)
-end
 
 """
 parse_curly(ps, ret)
@@ -230,17 +221,17 @@ Parses the juxtaposition of `ret` with an opening brace. Parses a comma
 seperated list.
 """
 function parse_curly(ps::ParseState, ret)
-    args = Any[ret, PUNCTUATION(next(ps))]
+    args = EXPR[ret, PUNCTUATION(next(ps))]
     parse_comma_sep(ps, args, true)
     accept_rbrace(ps, args)
-    return EXPR{Curly}(args)
+    return EXPR(Curly, args)
 end
 
 function parse_braces(ps::ParseState)
-    args = Any[PUNCTUATION(ps)]
+    args = EXPR[PUNCTUATION(ps)]
     parse_comma_sep(ps, args, true)
     accept_rbrace(ps, args)
-    return EXPR{Braces}(args)
+    return EXPR(Braces, args)
 end
 
 

--- a/src/components/operators.jl
+++ b/src/components/operators.jl
@@ -173,7 +173,7 @@ function parse_unary(ps::ParseState, op)
 end
 
 function parse_unary_colon(ps::ParseState, op)
-    op = requires_no_ws(op)
+    op = requires_no_ws(op, ps)
     if Tokens.begin_keywords < ps.nt.kind < Tokens.end_keywords
         ret = EXPR(Quotenode, EXPR[op, mIDENTIFIER(next(ps))])
     elseif Tokens.begin_literal < ps.nt.kind < Tokens.end_literal ||
@@ -208,10 +208,10 @@ end
 
 # Parse conditionals
 function parse_operator_cond(ps::ParseState, @nospecialize(ret), op)
-    ret = requires_ws(ret)
-    op = requires_ws(op)
+    ret = requires_ws(ret, ps)
+    op = requires_ws(op, ps)
     nextarg = @closer ps ifop parse_expression(ps)
-    op2 = requires_ws(mOPERATOR(next(ps)))
+    op2 = requires_ws(mOPERATOR(next(ps)), ps)
     nextarg2 = @closer ps comma @precedence ps 0 parse_expression(ps)
 
     fullspan = ret.fullspan + op.fullspan + nextarg.fullspan + op2.fullspan + nextarg2.fullspan

--- a/src/components/operators.jl
+++ b/src/components/operators.jl
@@ -197,7 +197,7 @@ function parse_operator_eq(ps::ParseState, @nospecialize(ret), op)
         end
         strip_where_scopes(ret)
         mark_sig_args!(ret)
-        ret = newscope!(mBinaryOpCall(ret, op, nextarg))
+        ret = setscope!(mBinaryOpCall(ret, op, nextarg))
         setbinding!(ret)
     else
         ret = mBinaryOpCall(ret, op, nextarg)
@@ -268,7 +268,7 @@ end
 
 
 # parse where
-function parse_operator_where(ps::ParseState, @nospecialize(ret), op, newscope = true)
+function parse_operator_where(ps::ParseState, @nospecialize(ret), op, setscope = true)
     nextarg = @precedence ps LazyAndOp @closer ps inwhere parse_expression(ps)
     
     if nextarg.typ === Braces
@@ -282,8 +282,8 @@ function parse_operator_where(ps::ParseState, @nospecialize(ret), op, newscope =
         end
     end
     ret = mWhereOpCall(ret, op, args)
-    if newscope
-        newscope!(ret)
+    if setscope
+        setscope!(ret)
     end
     return ret
 end

--- a/src/components/operators.jl
+++ b/src/components/operators.jl
@@ -40,15 +40,16 @@ precedence(kind::Tokens.Kind) = kind == Tokens.DDDOT ? DddotOp :
 
 precedence(x) = 0
 precedence(x::AbstractToken) = precedence(x.kind)
-precedence(x::OPERATOR) = precedence(x.kind)
+precedence(x::EXPR) = precedence(x.kind)
 
 
 isoperator(kind) = Tokens.begin_ops < kind < Tokens.end_ops
 isoperator(t::AbstractToken) = isoperator(t.kind)
+isoperator(x::EXPR) = x.typ === OPERATOR
 
 
 isunaryop(op) = false
-isunaryop(op::OPERATOR) = isunaryop(op.kind)
+isunaryop(op::EXPR) = isoperator(op) && isunaryop(op.kind)
 isunaryop(t::AbstractToken) = isunaryop(t.kind)
 isunaryop(kind::Tokens.Kind) = kind == Tokens.ISSUBTYPE ||
                   kind == Tokens.ISSUPERTYPE ||
@@ -78,7 +79,7 @@ isunaryandbinaryop(kind::Tokens.Kind) = kind == Tokens.PLUS ||
                            kind == Tokens.COLON
 
 isbinaryop(op) = false
-isbinaryop(op::OPERATOR) = isbinaryop(op.kind)
+isbinaryop(op::EXPR) = isoperator(op) && isbinaryop(op.kind)
 isbinaryop(t::AbstractToken) = isbinaryop(t.kind)
 isbinaryop(kind::Tokens.Kind) = isoperator(kind) &&
                     !(kind == Tokens.SQUARE_ROOT ||
@@ -112,7 +113,7 @@ end
 
 
 issyntaxcall(op) = false
-function issyntaxcall(op::OPERATOR)
+function issyntaxcall(op::EXPR)
     K = op.kind
     P = precedence(K)
     P == AssignmentOp && !(K == Tokens.APPROX || K == Tokens.PAIR_ARROW) ||
@@ -126,16 +127,19 @@ function issyntaxcall(op::OPERATOR)
     K == Tokens.DOT ||
     K == Tokens.DDDOT ||
     K == Tokens.PRIME ||
-    K == Tokens.WHERE
+    K == Tokens.WHERE||
+    K == Tokens.ANON_FUNC
 end
 
 
 issyntaxunarycall(op) = false
-function issyntaxunarycall(op::OPERATOR)
+function issyntaxunarycall(op::EXPR)
     K = op.kind
     !op.dot && (K == Tokens.EX_OR ||
     K == Tokens.AND ||
     K == Tokens.DECLARATION ||
+    K == Tokens.DDDOT ||
+    K == Tokens.PRIME ||
     K == Tokens.ISSUBTYPE ||
     K == Tokens.ISSUPERTYPE)
 end
@@ -150,9 +154,9 @@ LtoR(prec::Int) = AssignmentOp ≤ prec ≤ LazyAndOp || prec == PowerOp
 
 Having hit a unary operator at the start of an expression return a call.
 """
-function parse_unary(ps::ParseState, op::OPERATOR)
+function parse_unary(ps::ParseState, op)
     K,dot = op.kind, op.dot
-    if op isa OPERATOR && op.kind == Tokens.COLON
+    if isoperator(op) && op.kind == Tokens.COLON
         ret = parse_unary_colon(ps, op)
     elseif (is_plus(op) || is_minus(op)) && (ps.nt.kind == Tokens.INTEGER || ps.nt.kind == Tokens.FLOAT) && isemptyws(ps.ws) && ps.nnt.kind!=Tokens.CIRCUMFLEX_ACCENT
         arg = LITERAL(next(ps))
@@ -163,27 +167,22 @@ function parse_unary(ps::ParseState, op::OPERATOR)
                     K == Tokens.AND ? DeclarationOp :
                     K == Tokens.EX_OR ? 20 : PowerOp
         arg = @closer ps unary @precedence ps prec parse_expression(ps)
-        if issyntaxunarycall(op)
-            ret = UnarySyntaxOpCall(op, arg)
-        else
-            ret = UnaryOpCall(op, arg)
-        end
+        ret = UnaryOpCall(op, arg)
     end
-
     return ret
 end
 
-function parse_unary_colon(ps::ParseState, op::OPERATOR)
+function parse_unary_colon(ps::ParseState, op)
     if Tokens.begin_keywords < ps.nt.kind < Tokens.end_keywords
-        ret = EXPR{Quotenode}(Any[op, IDENTIFIER(next(ps))])
+        ret = EXPR(Quotenode, EXPR[op, IDENTIFIER(next(ps))])
     elseif Tokens.begin_literal < ps.nt.kind < Tokens.end_literal ||
         isoperator(ps.nt.kind) || ps.nt.kind == Tokens.IDENTIFIER
-        ret = EXPR{Quotenode}(Any[op, INSTANCE(next(ps))])
+        ret = EXPR(Quotenode, EXPR[op, INSTANCE(next(ps))])
     elseif closer(ps)
         ret = op
     else
         arg = @precedence ps 20 parse_expression(ps)
-        ret = EXPR{Quote}(Any[op, arg])
+        ret = EXPR(Quote, EXPR[op, arg])
     end
     return ret
 end
@@ -191,10 +190,10 @@ end
 function parse_operator_eq(ps::ParseState, @nospecialize(ret), op)
     nextarg = @precedence ps AssignmentOp - LtoR(AssignmentOp) parse_expression(ps)
 
-    if is_func_call(ret) && !(nextarg isa EXPR{Begin} || (nextarg isa EXPR{InvisBrackets} && nextarg.args[2] isa EXPR{Block}))
-        nextarg = EXPR{Block}(Any[nextarg])
+    if is_func_call(ret) && !(nextarg.typ === Begin || (nextarg.typ === InvisBrackets && nextarg.args[2].typ === Block))
+        nextarg = EXPR(Block, EXPR[nextarg])
     end
-    return BinarySyntaxOpCall(ret, op, nextarg)
+    return BinaryOpCall(ret, op, nextarg)
 end
 
 # Parse conditionals
@@ -203,22 +202,21 @@ function parse_operator_cond(ps::ParseState, @nospecialize(ret), op)
     op2 = OPERATOR(next(ps))
     nextarg2 = @closer ps comma @precedence ps 0 parse_expression(ps)
 
-    return ConditionalOpCall(ret, op, nextarg, op2, nextarg2)
+    fullspan = ret.fullspan + op.fullspan + nextarg.fullspan + op2.fullspan + nextarg2.fullspan
+    return EXPR(ConditionalOpCall, EXPR[ret, op, nextarg, op2, nextarg2], fullspan, fullspan - nextarg2.fullspan + nextarg2.span)
 end
 
 # Parse comparisons
 function parse_comp_operator(ps::ParseState, @nospecialize(ret), op)
     nextarg = @precedence ps ComparisonOp - LtoR(ComparisonOp) parse_expression(ps)
 
-    if ret isa EXPR{Comparison}
+    if ret.typ === Comparison
         push!(ret, op)
         push!(ret, nextarg)
-    elseif ret isa BinaryOpCall && precedence(ret.op) == ComparisonOp
-        ret = EXPR{Comparison}(Any[ret.arg1, ret.op, ret.arg2, op, nextarg])
-    elseif ret isa BinarySyntaxOpCall && (is_issubt(ret.op) || is_issupt(ret.op))
-        ret = EXPR{Comparison}(Any[ret.arg1, ret.op, ret.arg2, op, nextarg])
-    elseif (is_issubt(op) || is_issupt(op))
-        ret = BinarySyntaxOpCall(ret, op, nextarg)
+    elseif ret.typ === BinaryOpCall && precedence(ret.args[2]) == ComparisonOp
+        ret = EXPR(Comparison, EXPR[ret.args[1], ret.args[2], ret.args[3], op, nextarg])
+    elseif ret.typ === BinaryOpCall && (is_issubt(ret.args[2]) || is_issupt(ret.args[2]))
+        ret = EXPR(Comparison, EXPR[ret.args[1], ret.args[2], ret.args[3], op, nextarg])
     else
         ret = BinaryOpCall(ret, op, nextarg)
     end
@@ -229,8 +227,8 @@ end
 function parse_operator_colon(ps::ParseState, @nospecialize(ret), op)
     nextarg = @precedence ps ColonOp - LtoR(ColonOp) parse_expression(ps)
 
-    if ret isa BinaryOpCall && is_colon(ret.op)
-        ret = EXPR{ColonOpCall}(Any[ret.arg1, ret.op, ret.arg2, op, nextarg])
+    if ret.typ === BinaryOpCall && is_colon(ret.args[2])
+        ret = EXPR(ColonOpCall, EXPR[ret.args[1], ret.args[2], ret.args[3], op, nextarg])
     else
         ret = BinaryOpCall(ret, op, nextarg)
     end
@@ -244,9 +242,9 @@ end
 function parse_operator_power(ps::ParseState, @nospecialize(ret), op)
     nextarg = @precedence ps PowerOp - LtoR(PowerOp) @closer ps inwhere parse_expression(ps)
     
-    if ret isa UnaryOpCall
-        nextarg = BinaryOpCall(ret.arg, op, nextarg)
-        ret = UnaryOpCall(ret.op, nextarg)
+    if ret.typ === UnaryOpCall
+        nextarg = BinaryOpCall(ret.args[2], op, nextarg)
+        ret = UnaryOpCall(ret.args[1], nextarg)
     else
         ret = BinaryOpCall(ret, op, nextarg)
     end
@@ -258,10 +256,10 @@ end
 function parse_operator_where(ps::ParseState, @nospecialize(ret), op)
     nextarg = @precedence ps LazyAndOp @closer ps inwhere parse_expression(ps)
     
-    if nextarg isa EXPR{Braces}
+    if nextarg.typ === Braces
         args = nextarg.args
     else
-        args = Any[nextarg]
+        args = EXPR[nextarg]
     end
     return WhereOpCall(ret, op, args)
 end
@@ -271,13 +269,13 @@ function parse_operator_dot(ps::ParseState, @nospecialize(ret), op)
         @static if VERSION > v"1.1-"
             iserred = ps.ws.kind != Tokens.EMPTY_WS
             sig = @default ps parse_call(ps, ret)
-            nextarg = EXPR{TupleH}(sig.args[2:end])
+            nextarg = EXPR(TupleH, sig.args[2:end])
             if iserred
                 nextarg = ErrorToken(nextarg)
             end
         else
             sig = @default ps parse_call(ps, ret)
-            nextarg = EXPR{TupleH}(sig.args[2:end])
+            nextarg = EXPR(TupleH, sig.args[2:end])
         end
     elseif iskw(ps.nt) || ps.nt.kind == Tokens.IN || ps.nt.kind == Tokens.ISA || ps.nt.kind == Tokens.WHERE
         nextarg = IDENTIFIER(next(ps))
@@ -285,7 +283,7 @@ function parse_operator_dot(ps::ParseState, @nospecialize(ret), op)
         op2 = OPERATOR(next(ps))
         if ps.nt.kind == Tokens.LPAREN
             nextarg = @closeparen ps @precedence ps DotOp - LtoR(DotOp) parse_expression(ps)
-            nextarg = EXPR{Quote}(Any[op2, nextarg])
+            nextarg = EXPR(Quote, EXPR[op2, nextarg])
         else    
             nextarg = @precedence ps DotOp - LtoR(DotOp) parse_unary(ps, op2)
         end
@@ -296,16 +294,16 @@ function parse_operator_dot(ps::ParseState, @nospecialize(ret), op)
         nextarg = @precedence ps DotOp - LtoR(DotOp) parse_expression(ps)
     end
 
-    if nextarg isa IDENTIFIER || nextarg isa EXPR{Vect} || (nextarg isa UnarySyntaxOpCall && is_exor(nextarg.arg1))
-        ret = BinarySyntaxOpCall(ret, op, Quotenode(nextarg))
-    elseif nextarg isa EXPR{MacroCall}
-        mname = BinarySyntaxOpCall(ret, op, Quotenode(nextarg.args[1]))
-        ret = EXPR{MacroCall}(Any[mname])
+    if isidentifier(nextarg) || nextarg.typ === Vect || (nextarg.typ === UnaryOpCall && is_exor(nextarg.args[1]))
+        ret = BinaryOpCall(ret, op, EXPR(Quotenode, EXPR[nextarg]))
+    elseif nextarg.typ === MacroCall
+        mname = BinaryOpCall(ret, op, EXPR(Quotenode, EXPR[nextarg.args[1]]))
+        ret = EXPR(MacroCall, EXPR[mname])
         for i = 2:length(nextarg.args)
             push!(ret, nextarg.args[i])
         end
     else
-        ret = BinarySyntaxOpCall(ret, op, nextarg)
+        ret = BinaryOpCall(ret, op, nextarg)
     end
     return ret
 end
@@ -313,24 +311,24 @@ end
 function parse_operator_anon_func(ps::ParseState, @nospecialize(ret), op)
     arg = @closer ps comma @precedence ps 0 parse_expression(ps)
     
-    if !(arg isa EXPR{Begin} || (arg isa EXPR{InvisBrackets} && arg.args[2] isa EXPR{Block}))
-        arg = EXPR{Block}(Any[arg])
+    if !(arg.typ === Begin || (arg.typ === InvisBrackets && arg.args[2].typ === Block))
+        arg = EXPR(Block, EXPR[arg])
     end
-    return BinarySyntaxOpCall(ret, op, arg)
+    return BinaryOpCall(ret, op, arg)
 end
 
 function parse_operator(ps::ParseState, @nospecialize(ret), op)
     K,dot = op.kind, op.dot
     P = precedence(K)
 
-    if ret isa EXPR{ChainOpCall} && (is_star(op) || is_plus(op)) && op.kind == ret.args[2].kind
+    if ret.typ === ChainOpCall && (is_star(op) || is_plus(op)) && op.kind == ret.args[2].kind
         nextarg = @precedence ps P - LtoR(P) parse_expression(ps)
         push!(ret, op)
         push!(ret, nextarg)
         ret = ret
-    elseif ret isa BinaryOpCall && (is_star(op) || is_plus(op)) && op.kind == ret.op.kind && !ret.op.dot && ret.op.span > 0
+    elseif ret.typ === BinaryOpCall && (is_star(op) || is_plus(op)) && op.kind == ret.args[2].kind && !ret.args[2].dot && ret.args[2].span > 0
         nextarg = @precedence ps P - LtoR(P) parse_expression(ps)
-        ret = EXPR{ChainOpCall}(Any[ret.arg1, ret.op, ret.arg2, op, nextarg])
+        ret = EXPR(ChainOpCall, EXPR[ret.args[1], ret.args[2], ret.args[3], op, nextarg])
     elseif is_eq(op)
         ret = parse_operator_eq(ps, ret, op)
     elseif is_cond(op)
@@ -344,7 +342,7 @@ function parse_operator(ps::ParseState, @nospecialize(ret), op)
     elseif is_dot(op)
         ret = parse_operator_dot(ps, ret, op)
     elseif is_dddot(op) || is_prime(op)
-        ret = UnarySyntaxOpCall(ret, op)
+        ret = UnaryOpCall(ret, op)
     elseif P == ComparisonOp
         ret = parse_comp_operator(ps, ret, op)
     elseif P == PowerOp
@@ -352,12 +350,7 @@ function parse_operator(ps::ParseState, @nospecialize(ret), op)
     else
         ltor = K == Tokens.LPIPE ? true : LtoR(P)
         nextarg = @precedence ps P - ltor parse_expression(ps)
-        
-        if issyntaxcall(op)
-            ret = BinarySyntaxOpCall(ret, op, nextarg)
-        else
-            ret = BinaryOpCall(ret, op, nextarg)
-        end
+        ret = BinaryOpCall(ret, op, nextarg)
     end
     return ret
 end

--- a/src/components/operators.jl
+++ b/src/components/operators.jl
@@ -238,7 +238,8 @@ end
 # Parse ranges
 function parse_operator_colon(ps::ParseState, @nospecialize(ret), op)  
     if isnewlinews(ps.ws)
-        op = mErrorToken(op)
+        ps.errored = true
+        op = mErrorToken(op, UnexpectedNewLine)
     end
     nextarg = @precedence ps ColonOp - LtoR(ColonOp) parse_expression(ps)
 
@@ -295,7 +296,8 @@ function parse_operator_dot(ps::ParseState, @nospecialize(ret), op)
             sig = @default ps parse_call(ps, ret)
             nextarg = EXPR(TupleH, sig.args[2:end])
             if iserred
-                nextarg = mErrorToken(nextarg)
+                ps.errored = true
+                nextarg = mErrorToken(nextarg, UnexpectedWhiteSpace)
             end
         else
             sig = @default ps parse_call(ps, ret)

--- a/src/components/strings.jl
+++ b/src/components/strings.jl
@@ -29,7 +29,7 @@ function parse_string_or_cmd(ps::ParseState, prefixed = false)
     iscmd = ps.t.kind == Tokens.CMD || ps.t.kind == Tokens.TRIPLE_CMD
 
     if ps.errored
-        return mErrorToken()
+        return mErrorToken(Unknown)
     end
 
     lcp = nothing
@@ -88,10 +88,9 @@ function parse_string_or_cmd(ps::ParseState, prefixed = false)
         while true
             if eof(input)
                 lspan = position(b)
-                # str = tostr(b)
                 if b.size == 0
-                # if sizeof(str) == 0
-                    ex = mErrorToken()
+                    ps.errored = true
+                    ex = mErrorToken(Unknown)
                 elseif istrip
                     str = tostr(b)
                     str = str[1:prevind(str, prevind(str, sizeof(str), 2))]

--- a/src/components/strings.jl
+++ b/src/components/strings.jl
@@ -28,9 +28,9 @@ function parse_string_or_cmd(ps::ParseState, prefixed = false)
     istrip = (ps.t.kind == Tokens.TRIPLE_STRING) || (ps.t.kind == Tokens.TRIPLE_CMD)
     iscmd = ps.t.kind == Tokens.CMD || ps.t.kind == Tokens.TRIPLE_CMD
 
-    if ps.errored
-        return mErrorToken(Unknown)
-    end
+    # if ps.errored
+    #     return mErrorToken(Unknown)
+    # end
 
     lcp = nothing
     exprs_to_adjust = []
@@ -89,7 +89,7 @@ function parse_string_or_cmd(ps::ParseState, prefixed = false)
             if eof(input)
                 lspan = position(b)
                 if b.size == 0
-                    ps.errored = true
+                    # ps.errored = true
                     ex = mErrorToken(Unknown)
                 elseif istrip
                     str = tostr(b)

--- a/src/components/strings.jl
+++ b/src/components/strings.jl
@@ -161,7 +161,7 @@ function parse_string_or_cmd(ps::ParseState, prefixed = false)
             for expr in exprs_to_adjust
                 for (i, a) in enumerate(ret.args)
                     if expr == a
-                        ret.args[i] = EXPR(expr.typ, nothing, expr.fullspan, expr.span, replace(expr.val, "\n$lcp" => "\n"), expr.kind, false, expr.parent)
+                        ret.args[i] = EXPR(expr.typ, nothing, expr.fullspan, expr.span, replace(expr.val, "\n$lcp" => "\n"), expr.kind, false, expr.parent, expr.scope, expr.binding, expr.ref)
                     end
                 end
             end

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -496,7 +496,9 @@ function Expr(x::EXPR)
         return ret
     elseif x.typ === Filter
         ret = Expr(:filter)
-        for a in x.args
+        push!(ret.args, convert_iter_assign(last(x.args)))
+        for i in 1:length(x.args)-1
+            a = x.args[i]
             if !(is_if(a) || ispunctuation(a))
                 push!(ret.args, convert_iter_assign(a))
             end

--- a/src/display.jl
+++ b/src/display.jl
@@ -34,7 +34,7 @@ function Base.show(io::IO, x::EXPR, d = 0, er = false)
             end
         end
     else
-        printstyled(io, " "^d, T.name.name, "  ", x.fullspan, "(", x.span, ")", color = c)
+        printstyled(io, " "^d, T, "  ", x.fullspan, "(", x.span, ")", color = c)
         x.scope != nothing && printstyled(" new scope", color = :green)
         x.binding != nothing && printstyled(" $(x.binding.name)", color = :blue)
         println()

--- a/src/display.jl
+++ b/src/display.jl
@@ -2,16 +2,13 @@ function Base.show(io::IO, x::EXPR, d = 0, er = false)
     T = x.typ
     c =  er ? :red : :normal
     if isidentifier(x)
-        printstyled(io, " "^d, "ID: ", x.val, "  ", x.fullspan, " (", x.span, ")\n", color = c)
-    elseif iskw(x)
-        printstyled(io, " "^d, x.kind, "  ", x.fullspan, " (", x.span, ")\n", color = c)
+        printstyled(io, " "^d, x.val, "  ", x.fullspan, "(", x.span, ")", color = :yellow)
+        x.binding != nothing && printstyled(" $(x.binding.name)", color = :blue)
+        println()
     elseif isoperator(x)
-        printstyled(io, " "^d, "OP: ", x.kind, "  ", x.fullspan, " (", x.span, ")\n", color = c)
-    elseif x.typ in (UnaryOpCall,BinaryOpCall)
-        printstyled(io, " "^d, T.name.name, "  ", x.fullspan, " (", x.span, ")\n", color = c)
-        for a in x
-            show(io, a, d + 1, er)
-        end
+        printstyled(io, " "^d, "OP: ", x.kind, "  ", x.fullspan, "(", x.span, ")\n", color = c)
+    elseif iskw(x)
+        printstyled(io, " "^d, x.kind, "  ", x.fullspan, "(", x.span, ")\n", color = :magenta)
     elseif ispunctuation(x)
         if x.kind == Tokens.LPAREN
             printstyled(io, " "^d, "(\n", color = c)
@@ -24,10 +21,10 @@ function Base.show(io::IO, x::EXPR, d = 0, er = false)
         elseif x.kind == Tokens.COMMA
             printstyled(io, " "^d, ",\n", color = c)
         else
-            printstyled(io, " "^d, "PUNC: ", x.kind, "  ", x.fullspan, " (", x.span, ")\n", color = c)
+            printstyled(io, " "^d, "PUNC: ", x.kind, "  ", x.fullspan, "(", x.span, ")\n", color = c)
         end
     elseif isliteral(x)
-        printstyled(io, " "^d, "LITERAL: ", x.val, "  ", x.fullspan, " (", x.span, ")\n", color = c)
+        printstyled(io, " "^d, "$(x.kind): ", x.val, "  ", x.fullspan, "(", x.span, ")\n", color = c)
     elseif x.typ === ErrorToken
         if isempty(x.args)
             printstyled(io, " "^d, "ErrorToken\n", color = :red )
@@ -37,7 +34,11 @@ function Base.show(io::IO, x::EXPR, d = 0, er = false)
             end
         end
     else
-        printstyled(io, " "^d, T.name.name, "  ", x.fullspan, " (", x.span, ")\n", color = c)
+        printstyled(io, " "^d, T.name.name, "  ", x.fullspan, "(", x.span, ")", color = c)
+        x.scope != nothing && printstyled(" new scope", color = :green)
+        x.binding != nothing && printstyled(" $(x.binding.name)", color = :blue)
+        println()
+        x.args == nothing && return
         for a in x.args
             show(io, a, d + 1, er)
         end

--- a/src/display.jl
+++ b/src/display.jl
@@ -1,6 +1,6 @@
 function Base.show(io::IO, x::EXPR, d = 0, er = false)
     T = x.typ
-    c =  er ? :red : :normal
+    c =  T === ErrorToken || er ? :red : :normal
     if isidentifier(x)
         printstyled(io, " "^d, x.val, "  ", x.fullspan, "(", x.span, ")", color = :yellow)
         x.binding != nothing && printstyled(" $(x.binding.name)", color = :blue)
@@ -25,14 +25,6 @@ function Base.show(io::IO, x::EXPR, d = 0, er = false)
         end
     elseif isliteral(x)
         printstyled(io, " "^d, "$(x.kind): ", x.val, "  ", x.fullspan, "(", x.span, ")\n", color = c)
-    elseif x.typ === ErrorToken
-        if isempty(x.args)
-            printstyled(io, " "^d, "ErrorToken\n", color = :red )
-        else
-            for a in x.args
-                show(io, a, d, true)
-            end
-        end
     else
         printstyled(io, " "^d, T, "  ", x.fullspan, "(", x.span, ")", color = c)
         x.scope != nothing && printstyled(" new scope", color = :green)

--- a/src/display.jl
+++ b/src/display.jl
@@ -3,7 +3,7 @@ function Base.show(io::IO, x::EXPR, d = 0, er = false)
     c =  T === ErrorToken || er ? :red : :normal
     if isidentifier(x)
         printstyled(io, " "^d, x.val, "  ", x.fullspan, "(", x.span, ")", color = :yellow)
-        x.binding != nothing && printstyled(" $(x.binding.name)", color = :blue)
+        x.binding != nothing && printstyled(" $(x.binding.name)", x.binding.t === nothing ? "" : "::", color = :blue)
         println()
     elseif isoperator(x)
         printstyled(io, " "^d, "OP: ", x.kind, "  ", x.fullspan, "(", x.span, ")\n", color = c)
@@ -27,8 +27,8 @@ function Base.show(io::IO, x::EXPR, d = 0, er = false)
         printstyled(io, " "^d, "$(x.kind): ", x.val, "  ", x.fullspan, "(", x.span, ")\n", color = c)
     else
         printstyled(io, " "^d, T, "  ", x.fullspan, "(", x.span, ")", color = c)
-        x.scope != nothing && printstyled(" new scope", color = :green)
-        x.binding != nothing && printstyled(" $(x.binding.name)", color = :blue)
+        x.scope != nothing && printstyled(io, " new scope", color = :green)
+        x.binding != nothing && printstyled(io, " $(x.binding.name)", x.binding.t === nothing ? "" : "::", color = :blue)
         println()
         x.args == nothing && return
         for a in x.args
@@ -37,5 +37,10 @@ function Base.show(io::IO, x::EXPR, d = 0, er = false)
     end
 end
 
+function Base.show(io::IO, scope::Scope)
+    println(io, scope.parent === nothing ? "Root scope:" : "Scope:")
+    println(io, scope.names isa Dict ? string("[", join(collect(keys(scope.names)), ","), "]") : "[]")
+    println(io, scope.modules isa Dict ? string("[", join(collect(keys(scope.modules)), ","), "]") : "[]")
+end
 
 

--- a/src/display.jl
+++ b/src/display.jl
@@ -1,56 +1,48 @@
-function Base.show(io::IO, x::EXPR{T}, d = 0, er = false) where T
-    printstyled(io, " "^d, T.name.name, "  ", x.fullspan, " (", x.span, ")\n", color = er ? :red : :normal)
-    for a in x.args
-        show(io, a, d + 1, er)
-    end
-end
-function Base.show(io::IO, x::EXPR{ErrorToken}, d = 0, er = false)
-    if isempty(x.args)
-        printstyled(io, " "^d, "ErrorToken\n", color = :red )
+function Base.show(io::IO, x::EXPR, d = 0, er = false)
+    T = x.typ
+    c =  er ? :red : :normal
+    if isidentifier(x)
+        printstyled(io, " "^d, "ID: ", x.val, "  ", x.fullspan, " (", x.span, ")\n", color = c)
+    elseif iskw(x)
+        printstyled(io, " "^d, x.kind, "  ", x.fullspan, " (", x.span, ")\n", color = c)
+    elseif isoperator(x)
+        printstyled(io, " "^d, "OP: ", x.kind, "  ", x.fullspan, " (", x.span, ")\n", color = c)
+    elseif x.typ in (UnaryOpCall,BinaryOpCall)
+        printstyled(io, " "^d, T.name.name, "  ", x.fullspan, " (", x.span, ")\n", color = c)
+        for a in x
+            show(io, a, d + 1, er)
+        end
+    elseif ispunctuation(x)
+        if x.kind == Tokens.LPAREN
+            printstyled(io, " "^d, "(\n", color = c)
+        elseif x.kind == Tokens.RPAREN
+            printstyled(io, " "^d, ")\n", color = c)
+        elseif x.kind == Tokens.LSQUARE
+            printstyled(io, " "^d, "[\n", color = c)
+        elseif x.kind == Tokens.RSQUARE
+            printstyled(io, " "^d, "]\n", color = c)
+        elseif x.kind == Tokens.COMMA
+            printstyled(io, " "^d, ",\n", color = c)
+        else
+            printstyled(io, " "^d, "PUNC: ", x.kind, "  ", x.fullspan, " (", x.span, ")\n", color = c)
+        end
+    elseif isliteral(x)
+        printstyled(io, " "^d, "LITERAL: ", x.val, "  ", x.fullspan, " (", x.span, ")\n", color = c)
+    elseif x.typ === ErrorToken
+        if isempty(x.args)
+            printstyled(io, " "^d, "ErrorToken\n", color = :red )
+        else
+            for a in x.args
+                show(io, a, d, true)
+            end
+        end
     else
+        printstyled(io, " "^d, T.name.name, "  ", x.fullspan, " (", x.span, ")\n", color = c)
         for a in x.args
-            show(io, a, d, true)
+            show(io, a, d + 1, er)
         end
     end
 end
 
 
-function Base.show(io::IO, x::T, d = 0, er = false) where T <: Union{BinaryOpCall,BinarySyntaxOpCall,UnaryOpCall,UnarySyntaxOpCall,ConditionalOpCall,WhereOpCall}
-    printstyled(io, " "^d, T.name.name, "  ", x.fullspan, " (", x.span, ")\n", color = er ? :red : :normal)
-    for a in x
-        show(io, a, d + 1, er)
-    end
-end
 
-function Base.show(io::IO, x::IDENTIFIER, d = 0, er = false) 
-    printstyled(io, " "^d, "ID: ", x.val, "  ", x.fullspan, " (", x.span, ")\n", color = er ? :red : :normal)
-end
-
-function Base.show(io::IO, x::PUNCTUATION, d = 0, er = false) 
-    c =  er ? :red : :normal
-    if x.kind == Tokens.LPAREN
-        printstyled(io, " "^d, "(\n", color = c)
-    elseif x.kind == Tokens.RPAREN
-        printstyled(io, " "^d, ")\n", color = c)
-    elseif x.kind == Tokens.LSQUARE
-        printstyled(io, " "^d, "[\n", color = c)
-    elseif x.kind == Tokens.RSQUARE
-        printstyled(io, " "^d, "]\n", color = c)
-    elseif x.kind == Tokens.COMMA
-        printstyled(io, " "^d, ",\n", color = c)
-    else
-        printstyled(io, " "^d, "PUNC: ", x.kind, "  ", x.fullspan, " (", x.span, ")\n", color = c)
-    end
-end
-
-function Base.show(io::IO, x::OPERATOR, d = 0, er = false) 
-    printstyled(io, " "^d, "OP: ", x.kind, "  ", x.fullspan, " (", x.span, ")\n", color = er ? :red : :normal)
-end
-
-function Base.show(io::IO, x::LITERAL, d = 0, er = false) 
-    printstyled(io, " "^d, "LITERAL: ", x.val, "  ", x.fullspan, " (", x.span, ")\n", color = er ? :red : :normal)
-end
-
-function Base.show(io::IO, x::KEYWORD, d = 0, er = false) 
-    printstyled(io, " "^d, x.kind, "  ", x.fullspan, " (", x.span, ")\n", color = er ? :red : :normal)
-end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,46 +1,54 @@
-is_func_call(x) = false
-is_func_call(x::EXPR{Call}) = true
-is_func_call(x::EXPR{InvisBrackets}) = is_func_call(x.args[2])
-is_func_call(x::UnaryOpCall) = true
-is_func_call(x::BinaryOpCall) = true
-function is_func_call(x::BinarySyntaxOpCall)
-    if is_decl(x.op)
-        return is_func_call(x.arg1)
+function is_func_call(x)
+    if x.typ === Call
+        return true
+    elseif x.typ === WhereOpCall
+        return is_func_call(x.args[1])
+    elseif x.typ === InvisBrackets
+        return is_func_call(x.args[2])
+    elseif x.typ === UnaryOpCall
+        return !(isoperator(x.args[1]) && x.args[1].kind in (Tokens.EX_OR, Tokens.DECLARATION))
+    elseif x.typ === BinaryOpCall
+        if issyntaxcall(x.args[2])
+            if is_decl(x.args[2])
+                return is_func_call(x.args[1])
+            else
+                return false
+            end
+        else
+            true
+        end
     else
         return false
     end
 end
-function is_func_call(x::WhereOpCall)
-    return is_func_call(x.arg1)
-end
 
-is_assignment(x) = x isa BinarySyntaxOpCall && is_eq(x.op)
+is_assignment(x) = x.typ === BinaryOpCall && is_eq(x.args[2])
 
 # OPERATOR
-is_exor(x) = x isa OPERATOR && x.kind == Tokens.EX_OR && x.dot == false
-is_decl(x) = x isa OPERATOR && x.kind == Tokens.DECLARATION
-is_issubt(x) = x isa OPERATOR && x.kind == Tokens.ISSUBTYPE
-is_issupt(x) = x isa OPERATOR && x.kind == Tokens.ISSUPERTYPE
-is_and(x) = x isa OPERATOR && x.kind == Tokens.AND && x.dot == false
-is_not(x) = x isa OPERATOR && x.kind == Tokens.NOT && x.dot == false
-is_plus(x) = x isa OPERATOR && x.kind == Tokens.PLUS && x.dot == false
-is_minus(x) = x isa OPERATOR && x.kind == Tokens.MINUS && x.dot == false
-is_star(x) = x isa OPERATOR && x.kind == Tokens.STAR && x.dot == false
-is_eq(x) = x isa OPERATOR && x.kind == Tokens.EQ && x.dot == false
-is_dot(x) = x isa OPERATOR && x.kind == Tokens.DOT
-is_ddot(x) = x isa OPERATOR && x.kind == Tokens.DDOT
-is_dddot(x) = x isa OPERATOR && x.kind == Tokens.DDDOT
-is_pairarrow(x) = x isa OPERATOR && x.kind == Tokens.PAIR_ARROW && x.dot == false
-is_in(x) = x isa OPERATOR && x.kind == Tokens.IN && x.dot == false
-is_elof(x) = x isa OPERATOR && x.kind == Tokens.ELEMENT_OF && x.dot == false
-is_colon(x) = x isa OPERATOR && x.kind == Tokens.COLON
-is_prime(x) = x isa OPERATOR && x.kind == Tokens.PRIME
-is_cond(x) = x isa OPERATOR && x.kind == Tokens.CONDITIONAL
-is_where(x) = x isa OPERATOR && x.kind == Tokens.WHERE
-is_anon_func(x) = x isa OPERATOR && x.kind == Tokens.ANON_FUNC
+is_exor(x) = isoperator(x) && x.kind == Tokens.EX_OR && x.dot == false
+is_decl(x) = isoperator(x) && x.kind == Tokens.DECLARATION
+is_issubt(x) = isoperator(x) && x.kind == Tokens.ISSUBTYPE
+is_issupt(x) = isoperator(x) && x.kind == Tokens.ISSUPERTYPE
+is_and(x) = isoperator(x) && x.kind == Tokens.AND && x.dot == false
+is_not(x) = isoperator(x) && x.kind == Tokens.NOT && x.dot == false
+is_plus(x) = isoperator(x) && x.kind == Tokens.PLUS && x.dot == false
+is_minus(x) = isoperator(x) && x.kind == Tokens.MINUS && x.dot == false
+is_star(x) = isoperator(x) && x.kind == Tokens.STAR && x.dot == false
+is_eq(x) = isoperator(x) && x.kind == Tokens.EQ && x.dot == false
+is_dot(x) = isoperator(x) && x.kind == Tokens.DOT
+is_ddot(x) = isoperator(x) && x.kind == Tokens.DDOT
+is_dddot(x) = isoperator(x) && x.kind == Tokens.DDDOT
+is_pairarrow(x) = isoperator(x) && x.kind == Tokens.PAIR_ARROW && x.dot == false
+is_in(x) = isoperator(x) && x.kind == Tokens.IN && x.dot == false
+is_elof(x) = isoperator(x) && x.kind == Tokens.ELEMENT_OF && x.dot == false
+is_colon(x) = isoperator(x) && x.kind == Tokens.COLON
+is_prime(x) = isoperator(x) && x.kind == Tokens.PRIME
+is_cond(x) = isoperator(x) && x.kind == Tokens.CONDITIONAL
+is_where(x) = isoperator(x) && x.kind == Tokens.WHERE
+is_anon_func(x) = isoperator(x) && x.kind == Tokens.ANON_FUNC
 
 # PUNCTUATION
-is_punc(x) = x isa PUNCTUATION && 
+is_punc(x) = x.typ === PUNC && 
     x.kind == Tokens.COMMA && 
     x.kind == Tokens.LPAREN &&
     x.kind == Tokens.RPAREN &&
@@ -48,80 +56,64 @@ is_punc(x) = x isa PUNCTUATION &&
     x.kind == Tokens.RBRACE &&
     x.kind == Tokens.LSQUARE &&
     x.kind == Tokens.RSQUARE
-is_comma(x) = x isa PUNCTUATION && x.kind == Tokens.COMMA
-is_lparen(x) = x isa PUNCTUATION && x.kind == Tokens.LPAREN
-is_rparen(x) = x isa PUNCTUATION && x.kind == Tokens.RPAREN
-is_lbrace(x) = x isa PUNCTUATION && x.kind == Tokens.LBRACE
-is_rbrace(x) = x isa PUNCTUATION && x.kind == Tokens.RBRACE
-is_lsquare(x) = x isa PUNCTUATION && x.kind == Tokens.LSQUARE
-is_rsquare(x) = x isa PUNCTUATION && x.kind == Tokens.RSQUARE
+is_comma(x) = ispunctuation(x) && x.kind == Tokens.COMMA
+is_lparen(x) = ispunctuation(x) && x.kind == Tokens.LPAREN
+is_rparen(x) = ispunctuation(x) && x.kind == Tokens.RPAREN
+is_lbrace(x) = ispunctuation(x) && x.kind == Tokens.LBRACE
+is_rbrace(x) = ispunctuation(x) && x.kind == Tokens.RBRACE
+is_lsquare(x) = ispunctuation(x) && x.kind == Tokens.LSQUARE
+is_rsquare(x) = ispunctuation(x) && x.kind == Tokens.RSQUARE
 
 # KEYWORD
-is_if(x) = x isa KEYWORD && x.kind == Tokens.IF
-is_module(x) = x isa KEYWORD && x.kind == Tokens.MODULE
-is_import(x) = x isa KEYWORD && x.kind == Tokens.IMPORT
-is_importall(x) = x isa KEYWORD && x.kind == Tokens.IMPORTALL
+is_if(x) = iskw(x) && x.kind == Tokens.IF
+is_module(x) = iskw(x) && x.kind == Tokens.MODULE
+is_import(x) = iskw(x) && x.kind == Tokens.IMPORT
+is_importall(x) = iskw(x) && x.kind == Tokens.IMPORTALL
 
 
 # Literals
-
-is_lit_string(x) = x isa LITERAL && (x.kind == Tokens.STRING || x.kind == Tokens.TRIPLE_STRING)
-
-is_valid_iterator(x) = false
-is_valid_iterator(x::BinarySyntaxOpCall) = is_eq(x.op) 
-is_valid_iterator(x::BinaryOpCall) = is_in(x.op) || is_elof(x.op)
-
-_arg_id(x) = x
-_arg_id(x::IDENTIFIER) = x
-_arg_id(x::EXPR{Quotenode}) = x.args[1]
-_arg_id(x::EXPR{Curly}) = _arg_id(x.args[1])
-_arg_id(x::EXPR{Kw}) = _arg_id(x.args[1])
+is_lit_string(x) = isliteral(x) && (x.kind == Tokens.STRING || x.kind == Tokens.TRIPLE_STRING)
 
 
-function _arg_id(x::UnarySyntaxOpCall)
-    if is_dddot(x.arg2)
-        return _arg_id(x.arg1)
-    else
+function _arg_id(x)
+    if x.typ === ID
+        return x
+    elseif x.typ === Quotenode
+        return x.args[1]
+    elseif x.typ === Curly || 
+           x.typ === Kw || 
+           x.typ === WhereOpCall ||
+           (x.typ === UnaryOpCall && is_dddot(x.args[2])) ||
+           (x.typ === BinaryOpCall && is_decl(x.args[2])) ||
+        return _arg_id(x.args[1])
+    else 
         return x
     end
 end
 
-function _arg_id(x::BinarySyntaxOpCall)
-    if is_decl(x.op)
-        return _arg_id(x.arg1)
-    else
-        return x
-    end
-end
-function _arg_id(x::WhereOpCall)
-    return _arg_id(x.arg1)
-end
 
 function get_where_params(x, params = [])
-    return params
-end
-
-function get_where_params(x::WhereOpCall, params = [])
-    for i = 1:length(x.args)
-        a = x.args[i]
-        if !(a isa PUNCTUATION)
-            param = rem_subtype(a)
-            param = rem_curly(param)
-            push!(params, str_value(param))
+    if x.typ === WhereOpCall
+        for i = 3:length(x.args)
+            a = x.args[i]
+            if !ispunctuation(a)
+                param = rem_subtype(a)
+                param = rem_curly(param)
+                push!(params, str_value(param))
+            end
         end
     end
     return params
 end
 
 function get_curly_params(x, params = [])
-    return params
-end
-function get_curly_params(x::EXPR{Curly}, params = [])
-    for i = 2:length(x.args)
-        a = x.args[i]
-        if !(a isa PUNCTUATION)
-            param = rem_subtype(a)
-            push!(params, str_value(param))
+    if x.typ == Curly
+        for i = 2:length(x.args)
+            a = x.args[i]
+            if !ispunctuation(a)
+                param = rem_subtype(a)
+                push!(params, str_value(param))
+            end
         end
     end
     return params
@@ -129,10 +121,11 @@ end
 
 
 
+
 function get_sig_params(x, params = [])
     get_where_params(x, params)
-    if x isa WhereOpCall && x.arg1 isa WhereOpCall
-        get_where_params(x.arg1, params)
+    if x.typ === WhereOpCall && x.args[1].typ === WhereOpCall
+        get_where_params(x.args[1], params)
     end
     x = rem_where(x)
     x = rem_call(x)
@@ -142,23 +135,23 @@ end
 
 
 function rem_subtype(x)
-    if x isa BinarySyntaxOpCall && x.op isa OPERATOR && x.op.kind == Tokens.ISSUBTYPE
-        return x.arg1
+    if x.typ === BinaryOpCall && isoperator(x.args[2]) && x.args[2].kind == Tokens.ISSUBTYPE
+        return x.args[1]
     else
         return x
     end
 end
 
 function rem_decl(x)
-    if x isa BinarySyntaxOpCall && is_decl(x.op)
-        return x.arg1
+    if x.typ === BinaryOpCall && is_decl(x.args[2])
+        return x.args[1]
     else
         return x
     end
 end
 
 function rem_curly(x)
-    if x isa EXPR{Curly}
+    if x.typ === Curly
         return x.args[1]
     else
         return x
@@ -166,7 +159,7 @@ function rem_curly(x)
 end
 
 function rem_call(x)
-    if x isa EXPR{Call}
+    if x.typ === Call
         return x.args[1]
     else
         return x
@@ -174,15 +167,15 @@ function rem_call(x)
 end
 
 function rem_where(x)
-    if x isa WhereOpCall
-        return rem_where(x.arg1)
+    if x.typ === WhereOpCall
+        return rem_where(x.args[1])
     else
         return x
     end
 end
 
 function rem_invis(x)
-    if x isa EXPR{InvisBrackets}
+    if x.typ === InvisBrackets
         return x.args[2]
     else
         return x
@@ -190,15 +183,15 @@ function rem_invis(x)
 end
 
 function rem_dddot(x)
-    if x isa UnarySyntaxOpCall && is_dddot(x.arg2)
-        return x.arg1
+    if x.typ === UnaryOpCall && is_dddot(x.args[2])
+        return x.args[1]
     else
         return x
     end
 end
 
 function rem_kw(x)
-    if x isa EXPR{Kw}
+    if x.typ === Kw
         return x.args[1]
     else
         return x
@@ -206,46 +199,37 @@ function rem_kw(x)
 end
 
 # Definitions
-defines_function(x) = false
-defines_function(x::EXPR{FunctionDef}) = true
-function defines_function(x::BinarySyntaxOpCall)
-    if is_eq(x.op)
-        sig = x.arg1
-        while true
-            if sig isa EXPR{Call}
-                return true
-            elseif sig isa BinarySyntaxOpCall && is_decl(sig.op) || sig isa WhereOpCall
-                sig = sig.arg1
-            elseif sig isa UnaryOpCall || sig isa UnarySyntaxOpCall# && sig.arg isa BinarySyntaxOpCall && is_decl(sig.arg.op) && sig.arg.arg1 isa EXPR{InvisBrackets}
-                return true
-            elseif sig isa BinaryOpCall || (sig isa BinarySyntaxOpCall && !(sig.op.kind == Tokens.DOT))
-                return true
-            else
-                return false
+function defines_function(x)
+    if x.typ === FunctionDef
+        return true
+    elseif x.typ === BinaryOpCall
+        if is_eq(x.args[2])
+            sig = x.args[1]
+            while true
+                if sig.typ === Call || sig.typ === UnaryOpCall || (sig.typ === BinaryOpCall && (sig.args[2].kind == Tokens.DOT || !issyntaxcall(sig.args[2])))
+                    return true
+                elseif sig.typ === BinaryOpCall && is_decl(sig.args[2]) || sig.typ === WhereOpCall
+                    sig = sig.args[1]
+                else
+                    return false
+                end
             end
         end
+        return false
+    else
+        return false
     end
-    return false
 end
 
-defines_macro(x) = false
-defines_macro(x::EXPR{Macro}) = true
 
-
-function defines_datatype(x)
-    defines_struct(x) || defines_abstract(x) || defines_primitive(x)
-end
-
-defines_struct(x) = x isa EXPR{Struct} || defines_mutable(x)
-defines_mutable(x) = x isa EXPR{Mutable}
-defines_abstract(x) = x isa EXPR{Abstract}
-function defines_primitive(x) 
-    x isa EXPR{Primitive}
-end
-
-defines_module(x) = x isa EXPR{ModuleH} || x isa EXPR{BareModule}
-
-defines_anon_function(x) = x isa BinarySyntaxOpCall && is_anon_func(x.op)
+defines_macro(x) = x.typ == Macro
+defines_datatype(x) = defines_struct(x) || defines_abstract(x) || defines_primitive(x)
+defines_struct(x) = x.typ === Struct || defines_mutable(x)
+defines_mutable(x) = x.typ === Mutable
+defines_abstract(x) = x.typ === Abstract
+defines_primitive(x) = x.typ === Primitive
+defines_module(x) = x.typ === ModuleH || x.typ === BareModule
+defines_anon_function(x) = x.typ === BinaryOpCall && is_anon_func(x.args[2])
 
 function has_sig(x)
     defines_datatype(x) || defines_function(x) || defines_macro(x) || defines_anon_function(x)
@@ -258,180 +242,152 @@ end
 Returns the full signature of function, macro and datatype definitions. 
 Should only be called when has_sig(x) == true.
 """
-get_sig(x::EXPR{Struct}) = x.args[2]
-get_sig(x::EXPR{Mutable}) = x.args[3]
-get_sig(x::EXPR{Abstract}) = length(x.args) == 4 ? x.args[3] : x.args[2]
-get_sig(x::EXPR{Primitive}) = x.args[3]
-get_sig(x::EXPR{FunctionDef}) = x.args[2]
-get_sig(x::EXPR{Macro}) = x.args[2]
-function get_sig(x::BinarySyntaxOpCall)
-    return x.arg1
-end
-
-function get_name(x::EXPR{T}) where T <: Union{Struct,Mutable,Abstract,Primitive}
-    sig = get_sig(x)
-    sig = rem_where(sig)
-    sig = rem_subtype(sig)
-    sig = rem_curly(sig)
-    return sig
-end
-
-function get_name(x::EXPR{T}) where T <: Union{ModuleH,BareModule}
-    x.args[2]
-end
-
-function get_name(sig)
-    sig = rem_where(sig)
-    sig = rem_decl(sig)
-    sig = rem_call(sig)
-    sig = rem_curly(sig)
-    sig = rem_invis(sig)
-    return sig
-end
-
-function get_name(x::EXPR{FunctionDef})
-    sig = get_sig(x)
-    sig = rem_where(sig)
-    sig = rem_decl(sig)
-    sig = rem_call(sig)
-    sig = rem_curly(sig)
-    sig = rem_invis(sig)
-    return sig
-end
-
-function get_name(x::EXPR{Macro})
-    sig = get_sig(x)
-    sig = rem_call(sig)
-    sig = rem_invis(sig)
-    return sig
-end
-
-
-function get_name(x::BinarySyntaxOpCall)
-    sig = x.arg1
-    if sig isa UnaryOpCall 
-        return sig.op
+function get_sig(x)
+    if x.typ === BinaryOpCall
+        return x.args[1]
+    elseif x.typ === Struct ||
+        x.typ === FunctionDef ||
+        x.typ === Macro
+        return x.args[2]
+    elseif x.typ === Mutable ||
+           x.typ === Abstract ||
+           x.typ === Primitive
+        return x.args[3]
     end
-    sig = rem_where(sig)
-    sig = rem_decl(sig)
-    sig = rem_call(sig)
-    sig = rem_curly(sig)
-    sig = rem_invis(sig)
 end
 
-function get_args(x::IDENTIFIER)
-    return []
+function get_name(x)
+    if x.typ in (Struct, Mutable, Abstract, Primitive)
+        sig = get_sig(x)
+        sig = rem_subtype(sig)
+        sig = rem_where(sig)
+        sig = rem_subtype(sig)
+        sig = rem_curly(sig)
+    elseif x.typ in (ModuleH,BareModule)
+        sig = x.args[2] 
+    elseif x.typ in (FunctionDef, Macro)
+        sig = get_sig(x)
+        sig = rem_where(sig)
+        sig = rem_decl(sig)
+        sig = rem_call(sig)
+        sig = rem_curly(sig)
+        sig = rem_invis(sig)
+    elseif x.typ === BinaryOpCall
+        sig = x.args[1]
+        if sig.typ === UnaryOpCall 
+            return sig.args[1]
+        end
+        sig = rem_where(sig)
+        sig = rem_decl(sig)
+        sig = rem_call(sig)
+        sig = rem_curly(sig)
+        sig = rem_invis(sig)
+    else
+        sig = rem_where(sig)
+        sig = rem_decl(sig)
+        sig = rem_call(sig)
+        sig = rem_curly(sig)
+        sig = rem_invis(sig)
+    end
 end
 
 function get_args(x)
-    if defines_anon_function(x) && !(x.arg1 isa EXPR{TupleH})
-        arg = x.arg1
+    if x.typ === IDENTIFIER
+        return []
+    elseif defines_anon_function(x) && !(x.args[1].typ === TupleH)
+        arg = x.args[1]
         arg = rem_invis(arg)
         arg = get_arg_name(arg)
         return [arg]
-    end
-    sig = get_sig(x)
-    sig = rem_where(sig)
-    sig = rem_decl(sig)
-    return get_args(sig)
-end
-
-function get_args(sig::EXPR{TupleH})
-    args = []
-    for i = 2:length(sig.args)
-        arg = sig.args[i]
-        arg isa PUNCTUATION && continue
-        arg isa EXPR{Parameters} && continue
-        arg_name = get_arg_name(arg)
-        push!(args, arg_name)
-    end
-    return args
-end
-
-
-function get_args(x::EXPR{Do})
-    args = []
-    for i = 1:length(x.args[3].args)
-        arg = x.args[3].args[i]
-        arg isa PUNCTUATION && continue
-        arg isa EXPR{Parameters} && continue
-        arg_name = get_arg_name(arg)
-        push!(args, arg_name)
-    end
-    return args
-end
-
-function get_args(sig::EXPR{Call})
-    args = []
-    sig = rem_where(sig)
-    sig = rem_decl(sig)
-    if sig isa EXPR{Call}
-        for i = 2:length(sig.args)
-            arg = sig.args[i]
-            arg isa PUNCTUATION && continue
-            if arg isa EXPR{Parameters}
-                for j = 1:length(arg.args)
-                    parg = arg.args[j]
-                    parg isa PUNCTUATION && continue
-                    parg_name = get_arg_name(parg)
-                    push!(args, parg_name)
-                end
-            else
-                arg_name = get_arg_name(arg)
-                push!(args, arg_name)
-            end
-        end
-    else
-        error("not sig: $sig")
-    end
-    return args
-end
-
-function get_args(x::EXPR{Struct})
-    args = []
-    for arg in x.args[3]
-        if !defines_function(arg)
-            arg = rem_decl(arg)
-            push!(args, arg)
-        end
-    end
-    return args
-end
-
-function get_args(x::EXPR{Mutable})
-    args = []
-    for arg in x.args[4]
-        if !defines_function(arg)
-            arg = rem_decl(arg)
-            push!(args, arg)
-        end
-    end
-    return args
-end
-
-function get_args(x::EXPR{Flatten})
-    get_args(x.args[1])
-end
-
-function get_args(x::EXPR{T}) where T <: Union{Generator,Filter}
-    args = []
-    if x.args[1] isa EXPR{Flatten} || x.args[1] isa EXPR{Generator}
-        append!(args, get_args(x.args[1]))
-    end
-
-    if x.args[3] isa EXPR{Filter}
-        return get_args(x.args[3])
-    else
-        for i = 3:length(x.args)
+    elseif x.typ === TupleH
+        args = []
+        for i = 2:length(x.args)
             arg = x.args[i]
-            if is_valid_iterator(arg)
-                arg = rem_decl(arg.arg1)
-                arg = flatten_tuple(arg)
-                arg = rem_decl.(arg)
-                append!(args, arg)
+            ispunctuation(arg) && continue
+            arg.typ === Parameters && continue
+            arg_name = get_arg_name(arg)
+            push!(args, arg_name)
+        end
+        return args
+    elseif x.typ === Do
+        args = []
+        for i = 1:length(x.args[3].args)
+            arg = x.args[3].args[i]
+            ispunctuation(arg) && continue
+            arg.typ === Parameters && continue
+            arg_name = get_arg_name(arg)
+            push!(args, arg_name)
+        end
+        return args
+    elseif x.typ === Call
+        args = []
+        sig = rem_where(x)
+        sig = rem_decl(sig)
+        if sig.typ === Call
+            for i = 2:length(sig.args)
+                arg = sig.args[i]
+                ispunctuation(arg) && continue
+                if arg.typ === Parameters
+                    for j = 1:length(arg.args)
+                        parg = arg.args[j]
+                        ispunctuation(parg) && continue
+                        parg_name = get_arg_name(parg)
+                        push!(args, parg_name)
+                    end
+                else
+                    arg_name = get_arg_name(arg)
+                    push!(args, arg_name)
+                end
+            end
+        else
+            error("not sig: $sig")
+        end
+        return args
+    elseif x.typ === Struct
+        args = []
+        for arg in x.args[3]
+            if !defines_function(arg)
+                arg = rem_decl(arg)
+                push!(args, arg)
             end
         end
         return args
+    elseif x.typ === Mutable
+        args = []
+        for arg in x.args[4]
+            if !defines_function(arg)
+                arg = rem_decl(arg)
+                push!(args, arg)
+            end
+        end
+        return args
+    elseif x.typ === Flatten
+        return get_args(x.args[1])
+    elseif x.typ in (Generator,Flatten)
+        args = []
+        if x.args[1].typ === Flatten || x.args[1].typ === Generator
+            append!(args, get_args(x.args[1]))
+        end
+
+        if x.args[3].typ === Filter
+            return get_args(x.args[3])
+        else
+            for i = 3:length(x.args)
+                arg = x.args[i]
+                if is_range(arg)
+                    arg = rem_decl(arg.args[1])
+                    arg = flatten_tuple(arg)
+                    arg = rem_decl.(arg)
+                    append!(args, arg)
+                end
+            end
+            return args
+        end
+    else
+        sig = get_sig(x)
+        sig = rem_where(sig)
+        sig = rem_decl(sig)
+        return get_args(sig)
     end
 end
 
@@ -449,31 +405,23 @@ end
 
 
 function get_arg_type(arg)
-    if arg isa BinarySyntaxOpCall && is_decl(arg.op)
-        return Expr(arg.arg2)
+    if arg.typ === BinaryOpCall && is_decl(arg.args[2])
+        return Expr(arg.args[3])
     else
         return :Any
     end
 end
 
-get_body(x::EXPR{ModuleH}) = x.args[3]
-get_body(x::EXPR{BareModule}) = x.args[3]
-get_body(x::EXPR{If}) = x.args[3]
-get_body(x::EXPR{For}) = x.args[3]
-get_body(x::EXPR{While}) = x.args[3]
-get_body(x::EXPR{FunctionDef}) = x.args[3]
-get_body(x::EXPR{Macro}) = x.args[3]
-get_body(x::EXPR{Struct}) = x.args[3]
-get_body(x::EXPR{Mutable}) = x.args[4]
+get_body(x) = x.typ === Mutable ? x.args[4] : x.args[3]
 
-
-flatten_tuple(x::EXPR{InvisBrackets}, out = []) = flatten_tuple(x.args[2], out)
 function flatten_tuple(x, out = [])
-    if x isa EXPR{TupleH}
+    if x.typ === TupleH
         for arg in x
-            arg isa PUNCTUATION && continue    
+            ispunctuation(arg) && continue    
             flatten_tuple(arg, out)
         end
+    elseif x.typ === InvisBrackets
+        return flatten_tuple(x.args[2], out)
     else
         push!(out, x)
     end
@@ -486,87 +434,67 @@ end
 Get the IDENTIFIER name of a variable, possibly in the presence of 
 type declaration operators.
 """
-function get_id(x::BinarySyntaxOpCall)
-    if is_issubt(x.op) || is_decl(x.op)
-        return get_id(x.arg1)
+function get_id(x)
+    if x.typ === BinaryOpCall && (is_issubt(x.args[2]) || is_decl(x.args[2])) ||
+        (x.type === UnaryOpCall && is_dddot(x.args[2])) ||
+        x.typ === WhereOpCall ||
+        x.typ === Curly
+        return get_id(x.args[1])
+    elseif x.typ === InvisBrackets
+        return get_id(x.args[2])
     else
         return x
     end
 end
 
-function get_id(x::WhereOpCall)
-    return get_id(x.arg1)
-end
 
-function get_id(x::UnarySyntaxOpCall)
-    if is_dddot(x.arg2)
-        return get_id(x.arg1)
-    else
-        return x
-    end
-end
+# """
+#     get_t(x)
 
-get_id(x::EXPR{Curly}) = get_id(x.args[1])
-get_id(x::EXPR{InvisBrackets}) = get_id(x.args[2])
-get_id(x) = x
-
+# Basic inference in the presence of type declarations.
+# """
+# get_t(x) = :Any
+# function get_t(x::BinaryOpCall) 
+#     if is_decl(x.args[2])
+#         return Expr(x.args[3])
+#     else
+#         return :Any
+#     end
+# end
 
 
-"""
-    get_t(x)
+# infer_t(x) = :Any
+# function infer_t(x::LITERAL)
+#     if x.kind == Tokens.INTEGER
+#         return :Int
+#     elseif x.kind == Tokens.FLOAT
+#         return :Float64
+#     elseif x.kind == Tokens.STRING
+#         return :String
+#     elseif x.kind == Tokens.TRIPLE_STRING
+#         return :String
+#     elseif x.kind == Tokens.CHAR
+#         return :Char
+#     elseif x.kind == Tokens.TRUE || x.kind == Tokens.FALSE
+#         return :Bool
+#     elseif x.kind == Tokens.CMD
+#         return :Cmd
+#     end
+# end
 
-Basic inference in the presence of type declarations.
-"""
-get_t(x) = :Any
-function get_t(x::BinarySyntaxOpCall) 
-    if is_decl(x.op)
-        return Expr(x.arg2)
-    else
-        return :Any
-    end
-end
-
-
-infer_t(x) = :Any
-function infer_t(x::LITERAL)
-    if x.kind == Tokens.INTEGER
-        return :Int
-    elseif x.kind == Tokens.FLOAT
-        return :Float64
-    elseif x.kind == Tokens.STRING
-        return :String
-    elseif x.kind == Tokens.TRIPLE_STRING
-        return :String
-    elseif x.kind == Tokens.CHAR
-        return :Char
-    elseif x.kind == Tokens.TRUE || x.kind == Tokens.FALSE
-        return :Bool
-    elseif x.kind == Tokens.CMD
-        return :Cmd
-    end
-end
-
-infer_t(x::EXPR{Vect}) = :(Array{Any,1})
-infer_t(x::EXPR{Vcat}) = :(Array{Any,N})
-infer_t(x::EXPR{TypedVcat}) = :(Array{$(Expr(x.args[1])),N})
-infer_t(x::EXPR{Hcat}) = :(Array{Any,2})
-infer_t(x::EXPR{TypedHcat}) = :(Array{$(Expr(x.args[1])),2})
-infer_t(x::EXPR{Quote}) = :Expr
-infer_t(x::EXPR{StringH}) = :String
-infer_t(x::EXPR{Quotenode}) = :QuoteNode
+# infer_t(x::EXPR{Vect}) = :(Array{Any,1})
+# infer_t(x::EXPR{Vcat}) = :(Array{Any,N})
+# infer_t(x::EXPR{TypedVcat}) = :(Array{$(Expr(x.args[1])),N})
+# infer_t(x::EXPR{Hcat}) = :(Array{Any,2})
+# infer_t(x::EXPR{TypedHcat}) = :(Array{$(Expr(x.args[1])),2})
+# infer_t(x::EXPR{Quote}) = :Expr
+# infer_t(x::EXPR{StringH}) = :String
+# infer_t(x::EXPR{Quotenode}) = :QuoteNode
 
 
 """
     contributes_scope(x)
 Checks whether the body of `x` is included in the toplevel namespace.
 """
-contributes_scope(x) = false
-contributes_scope(x::EXPR{FileH}) = true
-contributes_scope(x::EXPR{Begin}) = true
-contributes_scope(x::EXPR{Block}) = true
-contributes_scope(x::EXPR{Const}) = true
-contributes_scope(x::EXPR{Global}) = true
-contributes_scope(x::EXPR{Local}) = true
-contributes_scope(x::EXPR{If}) = true
-contributes_scope(x::EXPR{MacroCall}) = true
-contributes_scope(x::EXPR{TopLevel}) = true
+contributes_scope(x) = x.typ in (FileH, Begin, Block, Const, Global, Local, If, MacroCall, TopLevel)
+

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -76,7 +76,7 @@ is_lit_string(x) = isliteral(x) && (x.kind == Tokens.STRING || x.kind == Tokens.
 
 
 function _arg_id(x)
-    if x.typ === ID
+    if x.typ === IDENTIFIER
         return x
     elseif x.typ === Quotenode
         return x.args[1]
@@ -288,16 +288,21 @@ function get_name(x)
         sig = rem_call(sig)
         sig = rem_curly(sig)
         sig = rem_invis(sig)
+        return get_name(sig)
     elseif x.typ === BinaryOpCall
+        if x.args[2].kind == Tokens.DOT
+            return get_name(x.args[3].args[1])
+        end
         sig = x.args[1]
         if sig.typ === UnaryOpCall 
-            return sig.args[1]
+            return get_name(sig.args[1])
         end
         sig = rem_where(sig)
         sig = rem_decl(sig)
         sig = rem_call(sig)
         sig = rem_curly(sig)
         sig = rem_invis(sig)
+        return get_name(sig)
     else
         sig = x
         if sig.typ === UnaryOpCall 

--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -175,3 +175,4 @@ function read_comment(l::Lexer)
 end
 
 isemptyws(t::AbstractToken) = t.kind == EmptyWS
+isnewlinews(t::AbstractToken) = t.kind === NewLineWS

--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -28,9 +28,8 @@ mutable struct Closer
     precedence::Int
     stop::Int
     cc::Vector{Symbol}
-    blocknewscope::Bool
 end
-Closer() = Closer(true, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, -1, typemax(Int), [], false)
+Closer() = Closer(true, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, -1, typemax(Int), [])
 
 struct Error
     loc::UnitRange{Int}
@@ -83,7 +82,6 @@ function next(ps::ParseState)
     else
         ps.nnt = Tokenize.Lexers.next_token(ps.l)
         ps.done = ps.nnt == Tokens.ENDMARKER
-        # ps.nnt, ps.done  = iterate(ps.l, ps.done)
     end
     
     # combines whitespace, comments and semicolons

--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -28,8 +28,9 @@ mutable struct Closer
     precedence::Int
     stop::Int
     cc::Vector{Symbol}
+    blocknewscope::Bool
 end
-Closer() = Closer(true, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, -1, typemax(Int), [])
+Closer() = Closer(true, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, -1, typemax(Int), [], false)
 
 struct Error
     loc::UnitRange{Int}

--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -50,6 +50,14 @@ function ParseState(str::Union{IO,String})
     return next(next(ps))
 end
 
+function ParseState(str::Union{IO,String}, loc::Int)
+    ps = ParseState(str)
+    while ps.nt.startbyte < loc
+        next(ps)
+    end
+    return ps
+end
+
 function Base.show(io::IO, ps::ParseState)
     println(io, "ParseState $(ps.done ? "finished " : "")at $(position(ps.l.io))")
     println(io, "last    : ", ps.lt.kind, " ($(ps.lt))", "    ($(wstype(ps.lws)))")

--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -31,11 +31,6 @@ mutable struct Closer
 end
 Closer() = Closer(true, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, -1, typemax(Int), [])
 
-struct Error
-    loc::UnitRange{Int}
-    description::String
-end
-
 mutable struct ParseState
     l::Lexer{Base.GenericIOBuffer{Array{UInt8, 1}},RawToken}
     done::Bool
@@ -49,10 +44,9 @@ mutable struct ParseState
     nnws::RawToken
     closer::Closer
     errored::Bool
-    errors::Vector{Error}
 end
 function ParseState(str::Union{IO,String})
-    ps = ParseState(tokenize(str, RawToken), false, RawToken(), RawToken(), RawToken(), RawToken(), RawToken(), RawToken(), RawToken(), RawToken(), Closer(), false, Error[])
+    ps = ParseState(tokenize(str, RawToken), false, RawToken(), RawToken(), RawToken(), RawToken(), RawToken(), RawToken(), RawToken(), RawToken(), Closer(), false)
     return next(next(ps))
 end
 

--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -49,7 +49,7 @@ mutable struct ParseState
     nnws::RawToken
     closer::Closer
     errored::Bool
-    errors::Vector
+    errors::Vector{Error}
 end
 function ParseState(str::Union{IO,String})
     ps = ParseState(tokenize(str, RawToken), false, RawToken(), RawToken(), RawToken(), RawToken(), RawToken(), RawToken(), RawToken(), RawToken(), Closer(), false, Error[])

--- a/src/recovery.jl
+++ b/src/recovery.jl
@@ -86,7 +86,7 @@ function recover_endmarker(ps)
     end
 end
 
-function requires_ws(x)
+function requires_ws(x, ps)
     if x.span == x.fullspan
         ps.errored = true
         return mErrorToken(x, Unknown)
@@ -95,7 +95,7 @@ function requires_ws(x)
     end
 end
 
-function requires_no_ws(x)
+function requires_no_ws(x, ps)
     if x.span != x.fullspan
         ps.errored = true
         return mErrorToken(x, UnexpectedWhiteSpace)

--- a/src/recovery.jl
+++ b/src/recovery.jl
@@ -81,3 +81,19 @@ function recover_endmarker(ps)
         end
     end
 end
+
+function requires_ws(x)
+    if x.span == x.fullspan
+        return mErrorToken(x)
+    else
+        return x
+    end
+end
+
+function requires_no_ws(x)
+    if x.span != x.fullspan
+        return mErrorToken(x)
+    else
+        return x
+    end
+end

--- a/src/recovery.jl
+++ b/src/recovery.jl
@@ -18,49 +18,49 @@ end
 
 function accept_rparen(ps)
     if ps.nt.kind == Tokens.RPAREN
-        return PUNCTUATION(next(ps))
+        return mPUNCTUATION(next(ps))
     else
         push!(ps.errors, Error((ps.ws.startbyte:ps.ws.endbyte) .+ 1 , "Expected )."))
-        return ErrorToken(PUNCTUATION(Tokens.RPAREN, 0, 0))
+        return mErrorToken(mPUNCTUATION(Tokens.RPAREN, 0, 0))
     end
 end
 accept_rparen(ps::ParseState, args) = push!(args, accept_rparen(ps))
 
 function accept_rsquare(ps)
     if ps.nt.kind == Tokens.RSQUARE
-        return PUNCTUATION(next(ps))
+        return mPUNCTUATION(next(ps))
     else
         push!(ps.errors, Error((ps.t.startbyte:ps.t.endbyte) .+ 1 , "Expected ]."))
-        return ErrorToken(PUNCTUATION(Tokens.RSQUARE, 0, 0))
+        return mErrorToken(mPUNCTUATION(Tokens.RSQUARE, 0, 0))
     end
 end
 accept_rsquare(ps::ParseState, args) = push!(args, accept_rsquare(ps))
 
 function accept_rbrace(ps)
     if ps.nt.kind == Tokens.RBRACE
-        return PUNCTUATION(next(ps))
+        return mPUNCTUATION(next(ps))
     else
         push!(ps.errors, Error((ps.t.startbyte:ps.t.endbyte) .+ 1 , "Expected }."))
-        return ErrorToken(PUNCTUATION(Tokens.RBRACE, 0, 0))
+        return mErrorToken(mPUNCTUATION(Tokens.RBRACE, 0, 0))
     end
 end
 accept_rbrace(ps::ParseState, args) = push!(args, accept_rbrace(ps))
 
 function accept_end(ps::ParseState)
     if ps.nt.kind == Tokens.END
-        return KEYWORD(next(ps))
+        return mKEYWORD(next(ps))
     else
         push!(ps.errors, Error((ps.t.startbyte:ps.t.endbyte) .+ 1 , "Expected end."))
-        return ErrorToken(KEYWORD(Tokens.END, 0, 0))
+        return mErrorToken(mKEYWORD(Tokens.END, 0, 0))
     end
 end
 accept_end(ps::ParseState, args) = push!(args, accept_end(ps))
 
 function accept_comma(ps)
     if ps.nt.kind == Tokens.COMMA
-        return PUNCTUATION(next(ps))
+        return mPUNCTUATION(next(ps))
     else
-        return PUNCTUATION(Tokens.RPAREN, 0, 0)
+        return mPUNCTUATION(Tokens.RPAREN, 0, 0)
     end
 end
 accept_comma(ps::ParseState, args) = push!(args, accept_comma(ps))
@@ -70,13 +70,13 @@ function recover_endmarker(ps)
         if !isempty(ps.closer.cc)
             closert = last(ps.closer.cc)
             if closert == :block
-                return ErrorToken(KEYWORD(Tokens.END, 0, 0))
+                return mErrorToken(mKEYWORD(Tokens.END, 0, 0))
             elseif closert == :paren
-                return ErrorToken(PUNCTUATION(Tokens.RPAREN, 0, 0))
+                return mErrorToken(mPUNCTUATION(Tokens.RPAREN, 0, 0))
             elseif closert == :square
-                return ErrorToken(PUNCTUATION(Tokens.RSQUARE, 0, 0))
+                return mErrorToken(mPUNCTUATION(Tokens.RSQUARE, 0, 0))
             elseif closert == :brace
-                return ErrorToken(PUNCTUATION(Tokens.RBRACE, 0, 0))
+                return mErrorToken(mPUNCTUATION(Tokens.RBRACE, 0, 0))
             end
         end
     end

--- a/src/reparse.jl
+++ b/src/reparse.jl
@@ -128,11 +128,14 @@ spanequiv(a::EXPR,b::EXPR) = a.span == b.span && a.fullspan == b.fullspan
 isequiv(a,b; span = true) = false
 
 function isequiv(a::EXPR,b::EXPR; span = true)
-    t = a.typ === b.typ 
-    length(a.args) != length(b.args) && return false
-    for i = 1:length(a.args)
-        t = t && isequiv(a.args[i], b.args[i], span = span) 
-        t || return false
+    t = a.typ === b.typ
+    typeof(a.args) != typeof(b.args) && return false
+    if a.args isa Vector
+        length(a.args) != length(b.args) && return false
+        for i = 1:length(a.args)
+            t = t && isequiv(a.args[i], b.args[i], span = span) 
+            t || return false
+        end
     end
     return (!span || spanequiv(a,b))
 end

--- a/src/reparse.jl
+++ b/src/reparse.jl
@@ -1,0 +1,138 @@
+
+const EXPRStack = Tuple{EXPR,Int,Int}
+
+function find_enclosing_expr(cst, offset, pos = 0, stack = EXPRStack[])
+    pos1 = pos
+    for (i,a) in enumerate(cst)
+        if pos < first(offset) < pos + a.span && pos < last(offset) < pos + a.span
+            push!(stack, (cst, pos1, i))
+            return find_enclosing_expr(a, offset, pos, stack)
+        else 
+            pos += a.fullspan
+        end
+    end
+    push!(stack, (cst, pos1, 0))
+    return stack
+end
+
+containing_expr(stack) = first(last(stack))
+parent_expr(stack) = first(stack[end-1])
+insert_size(inserttext, insertrange) = sizeof(inserttext) - max(last(insertrange) - first(insertrange), 0)
+enclosing_expr_range(stack, insertsize) = last(stack)[2] .+ (1:first(last(stack)).fullspan + insertsize)
+
+function reparse(edittedtext::String, inserttext::String, insertrange::UnitRange{Int}, oldcst)
+    #need to handle empty replacement case, i.e. inserttext = ""
+    stack = find_enclosing_expr(oldcst, insertrange)
+    insertsize = insert_size(inserttext, insertrange)
+    reparsed = reparse(stack, edittedtext, insertsize, oldcst)
+    return reparsed, oldcst
+end
+
+
+function replace_args!(replacement_args, stack)
+    pexpr, ppos, pi = stack[end-1]
+    oldspan, oldfullspan = pexpr.args[pi].span, pexpr.args[pi].fullspan
+    if length(replacement_args) > 1
+        deleteat!(pexpr.args, pi)
+        for i = 0:length(replacement_args)-1
+            insert!(pexpr.args, pi + i, replacement_args[1 + i])
+        end
+    else
+        pexpr.args[pi] = replacement_args[1]
+        dfullspan = replacement_args[1].fullspan - oldfullspan
+        @info "Replacing $(typeof(pexpr)) at $(pi)"
+        fix_stack_span(stack, dfullspan, replacement_args[1].span - replacement_args[1].fullspan)
+    end 
+end
+
+function reparse(stack::Array{EXPRStack}, edittedtext::String, insertsize::Int, oldcst)
+    # Assume no existing error in CST
+    # need to update (full)spans
+    if length(stack) == 1
+        return false
+    else
+        if parent_expr(stack) isa EXPR{FileH} 
+            replacement_args = parse(edittedtext[enclosing_expr_range(stack, insertsize)], true).args
+        elseif parent_expr(stack) isa EXPR{Block} && !(length(stack) > 2 && stack[end-2] isa EXPR{If})
+            replacement_args = let 
+                ps = ParseState(edittedtext[enclosing_expr_range(stack, insertsize)])
+                newblockargs = Any[]
+                CSTParser.parse_block(ps, newblockargs)
+            end
+        else
+            pop!(stack)
+            return reparse(stack, edittedtext, insertsize, oldcst)
+        end
+        replace_args!(replacement_args, stack)
+        return true
+    end
+    return false
+end
+
+function fixlastchild(x, pi, dspan)
+    nx = length(x)
+    if pi == nx
+        x[pi] = x.fullspan - dspan
+        return true
+    elseif x[nx].fullspan == 0 
+        for i = nx-1:-1:1
+            if x[i].fullspan > 0
+                x[pi] = x.fullspan - dspan
+                return true
+            end
+        end
+    end
+    return false
+end
+
+function fix_stack_span(stack::Array{EXPRStack}, dfullspan, dspan)
+    islast = true
+    for i = length(stack)-1:-1:1
+        stack[i][1].fullspan += dfullspan
+        if islast && stack[i][3] == length(stack[i][1])
+            stack[i][1].span = stack[i][1].fullspan + dspan
+        else
+            stack[i][1].span += dfullspan
+            islast = false
+        end
+    end
+end
+
+function reparse_test(text, insertrange, inserttext)
+    cst = parse(text, true) 
+    cst0 = deepcopy(cst)
+    edittedtext = edit_string(text, insertrange, inserttext)
+    reparsed, reparsed_cst = reparse(edittedtext, inserttext, insertrange, cst)
+    new_cst = CSTParser.parse(edittedtext, true)
+    return reparsed, isequiv(new_cst, reparsed_cst), text, edittedtext, cst0, new_cst, reparsed_cst
+end
+
+function edit_string(text, insertrange, inserttext)
+    if first(insertrange) == last(insertrange) == 0
+        text = string(inserttext, text)
+    elseif first(insertrange) == 0 && last(insertrange) == sizeof(text)
+        text = inserttext
+    elseif first(insertrange) == 0
+        text = string(inserttext, text[nextind(text, last(insertrange)):end])
+    elseif first(insertrange) == last(insertrange) == sizeof(text)
+        text = string(text, inserttext)
+    elseif last(insertrange) == sizeof(text)
+        text = string(text[1:first(insertrange)], inserttext)
+    else
+        text = string(text[1:first(insertrange)], inserttext, text[nextind(text, last(insertrange)):end])
+    end    
+end
+
+spanequiv(a::EXPR,b::EXPR) = a.span == b.span && a.fullspan == b.fullspan
+ 
+isequiv(a,b; span = true) = false
+
+function isequiv(a::EXPR,b::EXPR; span = true)
+    t = a.typ === b.typ 
+    length(a.args) != length(b.args) && return false
+    for i = 1:length(a.args)
+        t = t && isequiv(a.args[i], b.args[i], span = span) 
+        t || return false
+    end
+    return (!span || spanequiv(a,b))
+end

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -119,9 +119,10 @@ mutable struct Scope
     parent::Union{Nothing,Scope}
     names::Dict{String,Binding}
     modules::Union{Nothing,Dict{String,Any}}
+    ismodule::Bool
 end
 
-Scope() = Scope(nothing, Dict{String,Binding}(), nothing)
+Scope() = Scope(nothing, Dict{String,Binding}(), nothing, false)
 
 mutable struct EXPR
     typ::Head

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -19,15 +19,77 @@ const PrimeOp       = 16
 const DddotOp       = 7
 const AnonFuncOp    = 14
 
+@enum(Head,IDENTIFIER,
+PUNCTUATION,
+OPERATOR,
+KEYWORD,
+LITERAL,
+NoHead,
+Call,
+UnaryOpCall,
+BinaryOpCall,
+WhereOpCall,
+ConditionalOpCall,
+ChainOpCall,
+ColonOpCall,
+Abstract,
+Begin,
+Block,
+Braces,
+BracesCat,
+Const,
+Comparison,
+Curly,
+Do,
+Filter,
+Flatten,
+For,
+FunctionDef,
+Generator,
+Global,
+GlobalRefDoc,
+If,
+Kw,
+Let,
+Local,
+Macro,
+MacroCall,
+MacroName,
+Mutable,
+Outer,
+Parameters,
+Primitive,
+Quote,
+Quotenode,
+InvisBrackets,
+StringH,
+Struct,
+Try,
+TupleH,
+FileH,
+Return,
+While,
+x_Cmd,
+x_Str,
+ModuleH,
+BareModule,
+TopLevel,
+Export,
+Import,
+ImportAll,
+Using,
+Comprehension,
+DictComprehension,
+TypedComprehension,
+Hcat,
+TypedHcat,
+Ref,
+Row,
+Vcat,
+TypedVcat,
+Vect,
+ErrorToken)
 
-abstract type LeafNode end
-abstract type Head end
-abstract type IDENTIFIER <: Head end
-abstract type PUNCTUATION <: Head end
-abstract type OPERATOR <: Head end
-abstract type KEYWORD <: Head end
-abstract type LITERAL <: Head end
-abstract type NoHead <: Head end
 
 const NoKind = Tokenize.Tokens.begin_keywords
 
@@ -52,7 +114,7 @@ end
 Scope() = Scope(nothing, Dict{String,Binding}(), nothing)
 
 mutable struct EXPR
-    typ::DataType
+    typ::Head
     args::Union{Nothing,Vector{EXPR}}
     fullspan::Int
     span::Int
@@ -65,7 +127,7 @@ mutable struct EXPR
     ref
 end
 
-function EXPR(T::DataType, args::Vector{EXPR}, fullspan, span)
+function EXPR(T::Head, args::Vector{EXPR}, fullspan, span)
     ex = EXPR(T, args, fullspan, span, nothing, NoKind, false, nothing, nothing, nothing, nothing)
     for c in args
         setparent!(c, ex)
@@ -73,7 +135,7 @@ function EXPR(T::DataType, args::Vector{EXPR}, fullspan, span)
     ex
 end
 
-function EXPR(T::DataType, args::Vector{EXPR})
+function EXPR(T::Head, args::Vector{EXPR})
     ret = EXPR(T, args, 0, 0)
     update_span!(ret)
     ret
@@ -82,24 +144,24 @@ end
 
 
 
-@noinline IDENTIFIER(ps::ParseState) = EXPR(IDENTIFIER, nothing, ps.nt.startbyte - ps.t.startbyte, ps.t.endbyte - ps.t.startbyte + 1, val(ps.t, ps), NoKind, false, nothing, nothing, nothing, nothing)
+@noinline mIDENTIFIER(ps::ParseState) = EXPR(IDENTIFIER, nothing, ps.nt.startbyte - ps.t.startbyte, ps.t.endbyte - ps.t.startbyte + 1, val(ps.t, ps), NoKind, false, nothing, nothing, nothing, nothing)
 
-PUNCTUATION(kind, fullspan, span) = EXPR(PUNCTUATION, nothing, fullspan, span, nothing, kind, false, nothing, nothing, nothing, nothing)
-@noinline PUNCTUATION(ps::ParseState) = EXPR(PUNCTUATION, nothing, ps.nt.startbyte - ps.t.startbyte, ps.t.endbyte - ps.t.startbyte + 1, nothing, ps.t.kind, false, nothing, nothing, nothing, nothing)
+mPUNCTUATION(kind, fullspan, span) = EXPR(PUNCTUATION, nothing, fullspan, span, nothing, kind, false, nothing, nothing, nothing, nothing)
+@noinline mPUNCTUATION(ps::ParseState) = EXPR(PUNCTUATION, nothing, ps.nt.startbyte - ps.t.startbyte, ps.t.endbyte - ps.t.startbyte + 1, nothing, ps.t.kind, false, nothing, nothing, nothing, nothing)
 
-OPERATOR(fullspan, span, kind, dotop) = EXPR(OPERATOR, nothing, fullspan, span, nothing, kind, dotop, nothing, nothing, nothing, nothing)
-@noinline OPERATOR(ps::ParseState) = EXPR(OPERATOR, nothing, ps.nt.startbyte - ps.t.startbyte, ps.t.endbyte - ps.t.startbyte + 1, nothing, ps.t.kind, ps.t.dotop, nothing, nothing, nothing, nothing)
+mOPERATOR(fullspan, span, kind, dotop) = EXPR(OPERATOR, nothing, fullspan, span, nothing, kind, dotop, nothing, nothing, nothing, nothing)
+@noinline mOPERATOR(ps::ParseState) = EXPR(OPERATOR, nothing, ps.nt.startbyte - ps.t.startbyte, ps.t.endbyte - ps.t.startbyte + 1, nothing, ps.t.kind, ps.t.dotop, nothing, nothing, nothing, nothing)
 
-KEYWORD(kind, fullspan, span) = EXPR(KEYWORD, nothing, fullspan, span, nothing, kind, false, nothing, nothing, nothing, nothing)
-@noinline KEYWORD(ps::ParseState) = EXPR(KEYWORD, nothing, ps.nt.startbyte - ps.t.startbyte, ps.t.endbyte - ps.t.startbyte + 1, nothing, ps.t.kind, false, nothing, nothing, nothing, nothing)
+mKEYWORD(kind, fullspan, span) = EXPR(KEYWORD, nothing, fullspan, span, nothing, kind, false, nothing, nothing, nothing, nothing)
+@noinline mKEYWORD(ps::ParseState) = EXPR(KEYWORD, nothing, ps.nt.startbyte - ps.t.startbyte, ps.t.endbyte - ps.t.startbyte + 1, nothing, ps.t.kind, false, nothing, nothing, nothing, nothing)
 
-LITERAL(fullspan::Int, span::Int, val::String, kind) = EXPR(LITERAL, nothing, fullspan, span, val, kind, false, nothing, nothing, nothing, nothing)
-@noinline function LITERAL(ps::ParseState) 
+mLITERAL(fullspan::Int, span::Int, val::String, kind) = EXPR(LITERAL, nothing, fullspan, span, val, kind, false, nothing, nothing, nothing, nothing)
+@noinline function mLITERAL(ps::ParseState) 
     if ps.t.kind == Tokens.STRING || ps.t.kind == Tokens.TRIPLE_STRING ||
         ps.t.kind == Tokens.CMD || ps.t.kind == Tokens.TRIPLE_CMD
          return parse_string_or_cmd(ps)
      else
-         LITERAL(ps.nt.startbyte - ps.t.startbyte, ps.t.endbyte - ps.t.startbyte + 1, val(ps.t, ps), ps.t.kind)
+         mLITERAL(ps.nt.startbyte - ps.t.startbyte, ps.t.endbyte - ps.t.startbyte + 1, val(ps.t, ps), ps.t.kind)
      end
 end
 
@@ -162,17 +224,17 @@ end
 
 function INSTANCE(ps::ParseState)
     if isidentifier(ps.t)
-        return IDENTIFIER(ps)
+        return mIDENTIFIER(ps)
     elseif isliteral(ps.t)
-        return LITERAL(ps)
+        return mLITERAL(ps)
     elseif iskw(ps.t)
-        return KEYWORD(ps)
+        return mKEYWORD(ps)
     elseif isoperator(ps.t)
-        return OPERATOR(ps)
+        return mOPERATOR(ps)
     elseif ispunctuation(ps.t)
-        return PUNCTUATION(ps)
+        return mPUNCTUATION(ps)
     else
-        return ErrorToken()
+        return mErrorToken()
     end
 end
 
@@ -191,21 +253,17 @@ mutable struct Project
     files::Vector{File}
 end
 
-abstract type Call <: Head end
-abstract type UnaryOpCall <: Head end
-abstract type BinaryOpCall <: Head end
-abstract type WhereOpCall <: Head end
-abstract type ConditionalOpCall <: Head end
 
 
-function UnaryOpCall(op, arg) 
+
+function mUnaryOpCall(op, arg) 
     fullspan = op.fullspan + arg.fullspan
     ex = EXPR(UnaryOpCall, EXPR[op, arg], fullspan, fullspan - arg.fullspan + arg.span)
     setparent!(op, ex)
     setparent!(op, ex)
     return ex
 end
-function BinaryOpCall(arg1, op, arg2) 
+function mBinaryOpCall(arg1, op, arg2) 
     fullspan = arg1.fullspan + op.fullspan + arg2.fullspan
     ex = EXPR(BinaryOpCall, EXPR[arg1, op, arg2], fullspan, fullspan - arg2.fullspan + arg2.span)
     setparent!(arg1, ex)
@@ -213,7 +271,7 @@ function BinaryOpCall(arg1, op, arg2)
     setparent!(arg2, ex)
     return ex
 end
-function WhereOpCall(arg1, op, args)
+function mWhereOpCall(arg1, op, args)
     ex = EXPR(WhereOpCall, EXPR[arg1; op; args], arg1.fullspan + op.fullspan, 0)
     setparent!(arg1, ex)
     setparent!(op, ex)
@@ -227,74 +285,13 @@ end
 
 
 
-abstract type ChainOpCall <: Head end
-abstract type ColonOpCall <: Head end
-abstract type Abstract <: Head end
-abstract type Begin <: Head end
-abstract type Block <: Head end
-abstract type Braces <: Head end
-abstract type BracesCat <: Head end
-abstract type Const <: Head end
-abstract type Comparison <: Head end
-abstract type Curly <: Head end
-abstract type Do <: Head end
-abstract type Filter <: Head end
-abstract type Flatten <: Head end
-abstract type For <: Head end
-abstract type FunctionDef <: Head end
-abstract type Generator <: Head end
-abstract type Global <: Head end
-abstract type GlobalRefDoc <: Head end
-abstract type If <: Head end
-abstract type Kw <: Head end
-abstract type Let <: Head end
-abstract type Local <: Head end
-abstract type Macro <: Head end
-abstract type MacroCall <: Head end
-abstract type MacroName <: Head end
-abstract type Mutable <: Head end
-abstract type Outer <: Head end
-abstract type Parameters <: Head end
-abstract type Primitive <: Head end
-abstract type Quote <: Head end
-abstract type Quotenode <: Head end
-abstract type InvisBrackets <: Head end
-abstract type StringH <: Head end
-abstract type Struct <: Head end
-abstract type Try <: Head end
-abstract type TupleH <: Head end
-abstract type FileH <: Head end
-abstract type Return <: Head end
-abstract type While <: Head end
-abstract type x_Cmd <: Head end
-abstract type x_Str <: Head end
 
-abstract type ModuleH <: Head end
-abstract type BareModule <: Head end
-abstract type TopLevel <: Head end
-abstract type Export <: Head end
-abstract type Import <: Head end
-abstract type ImportAll <: Head end
-abstract type Using <: Head end
+mErrorToken() = EXPR(ErrorToken, EXPR[])
+mErrorToken(x) = EXPR(ErrorToken, EXPR[x])
 
-abstract type Comprehension <: Head end
-abstract type DictComprehension <: Head end
-abstract type TypedComprehension <: Head end
-abstract type Hcat <: Head end
-abstract type TypedHcat <: Head end
-abstract type Ref <: Head end
-abstract type Row <: Head end
-abstract type Vcat <: Head end
-abstract type TypedVcat <: Head end
-abstract type Vect <: Head end
-
-abstract type ErrorToken <: Head end
-ErrorToken() = EXPR(ErrorToken, EXPR[])
-ErrorToken(x) = EXPR(ErrorToken, EXPR[x])
-
-TRUE() = LITERAL(0, 0, "", Tokens.TRUE)
-FALSE() = LITERAL(0, 0, "", Tokens.FALSE)
-NOTHING() = LITERAL(0, 0, "", Tokens.NOTHING)
+TRUE() = mLITERAL(0, 0, "", Tokens.TRUE)
+FALSE() = mLITERAL(0, 0, "", Tokens.FALSE)
+NOTHING() = mLITERAL(0, 0, "", Tokens.NOTHING)
 GlobalRefDOC() = EXPR(GlobalRefDoc, EXPR[])
 
 function setparent!(c, p)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -36,8 +36,7 @@ function closer(ps::ParseState)
             (isunaryop(ps.t) && ps.ws.kind == WS)
         )) ||
     (ps.nt.startbyte ≥ ps.closer.stop) ||
-    (ps.closer.unary && (ps.t.kind in (Tokens.INTEGER, Tokens.FLOAT, Tokens.RPAREN, Tokens.RSQUARE,Tokens.RBRACE) && ps.nt.kind == Tokens.IDENTIFIER)) ||
-    ps.errored
+    (ps.closer.unary && (ps.t.kind in (Tokens.INTEGER, Tokens.FLOAT, Tokens.RPAREN, Tokens.RSQUARE,Tokens.RBRACE) && ps.nt.kind == Tokens.IDENTIFIER))
 end
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -243,27 +243,6 @@ isajuxtaposition(ps::ParseState, ret) = ((is_number(ret) && (ps.nt.kind == Token
         ((ps.t.kind == Tokens.STRING || ps.t.kind == Tokens.TRIPLE_STRING) && (ps.nt.kind == Tokens.STRING || ps.nt.kind == Tokens.TRIPLE_STRING)))) || ((ps.t.kind in (Tokens.INTEGER, Tokens.FLOAT) || ps.t.kind in (Tokens.RPAREN,Tokens.RSQUARE,Tokens.RBRACE)) && ps.nt.kind == Tokens.IDENTIFIER)
 
 
-# Testing functions
-
-
-
-function test_order(x, out = [])
-    if x isa EXPR
-        for y in x
-            test_order(y, out)
-        end
-    else
-        push!(out, x)
-    end
-    out
-end
-
-function test_find(str)
-    x = parse(str, true)
-    for i = 1:sizeof(str)
-        _find(x, i)
-    end
-end
 
 # When using the FancyDiagnostics package, Base.parse, is the
 # same as CSTParser.parse. Manually call the flisp parser here
@@ -627,5 +606,4 @@ function match_closer(ps::ParseState)
            (kind === Tokens.RSQUARE && lc == :square) ||
            (kind === Tokens.RBRACE && lc == :braces) ||
            (kind === Tokens.END && (lc == :begin || lc == :if)) 
-
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -208,13 +208,16 @@ end
 
 
 isidentifier(t::AbstractToken) = t.kind == Tokens.IDENTIFIER
+isidentifier(x::EXPR) = x.typ === IDENTIFIER
 
 isliteral(t::AbstractToken) = Tokens.begin_literal < t.kind < Tokens.end_literal
+isliteral(x::EXPR) = x.typ === LITERAL
 
 isbool(t::AbstractToken) =  Tokens.TRUE ≤ t.kind ≤ Tokens.FALSE
 iscomma(t::AbstractToken) =  t.kind == Tokens.COMMA
 
 iskw(t::AbstractToken) = Tokens.iskeyword(t.kind)
+iskw(x::EXPR) = x.typ === KEYWORD
 
 isinstance(t::AbstractToken) = isidentifier(t) ||
                        isliteral(t) ||
@@ -226,17 +229,16 @@ ispunctuation(t::AbstractToken) = t.kind == Tokens.COMMA ||
                           t.kind == Tokens.END ||
                           Tokens.LSQUARE ≤ t.kind ≤ Tokens.RPAREN || 
                           t.kind == Tokens.AT_SIGN
+ispunctuation(x::EXPR) = x.typ === PUNCTUATION
 
-isstring(x) = false
-isstring(x::EXPR{StringH}) = true
-isstring(x::LITERAL) = x.kind == Tokens.STRING || x.kind == Tokens.TRIPLE_STRING
-is_integer(x) = x isa LITERAL && x.kind == Tokens.INTEGER
-is_float(x) = x isa LITERAL && x.kind == Tokens.FLOAT
-is_number(x) = x isa LITERAL && (x.kind == Tokens.INTEGER || x.kind == Tokens.FLOAT)
-is_nothing(x) = x isa LITERAL && x.kind == Tokens.NOTHING
+isstring(x) = x.typ === StringH || (isliteral(x) && (x.kind == Tokens.STRING || x.kind == Tokens.TRIPLE_STRING))
+is_integer(x) = isliteral(x) && x.kind == Tokens.INTEGER
+is_float(x) = isliteral(x) && x.kind == Tokens.FLOAT
+is_number(x) = isliteral(x) && (x.kind == Tokens.INTEGER || x.kind == Tokens.FLOAT)
+is_nothing(x) = isliteral(x) && x.kind == Tokens.NOTHING
 
 isajuxtaposition(ps::ParseState, ret) = ((is_number(ret) && (ps.nt.kind == Tokens.IDENTIFIER || ps.nt.kind == Tokens.LPAREN || ps.nt.kind == Tokens.CMD || ps.nt.kind == Tokens.STRING || ps.nt.kind == Tokens.TRIPLE_STRING)) || 
-        ((ret isa UnarySyntaxOpCall && is_prime(ret.arg2) && ps.nt.kind == Tokens.IDENTIFIER) ||
+        ((ret.typ === UnaryOpCall && is_prime(ret.args[2]) && ps.nt.kind == Tokens.IDENTIFIER) ||
         ((ps.t.kind == Tokens.RPAREN || ps.t.kind == Tokens.RSQUARE) && (ps.nt.kind == Tokens.IDENTIFIER || ps.nt.kind == Tokens.CMD)) ||
         ((ps.t.kind == Tokens.STRING || ps.t.kind == Tokens.TRIPLE_STRING) && (ps.nt.kind == Tokens.STRING || ps.nt.kind == Tokens.TRIPLE_STRING)))) || ((ps.t.kind in (Tokens.INTEGER, Tokens.FLOAT) || ps.t.kind in (Tokens.RPAREN,Tokens.RSQUARE,Tokens.RBRACE)) && ps.nt.kind == Tokens.IDENTIFIER)
 
@@ -492,62 +494,9 @@ check_span(x, neq = [])
 Recursively checks whether the span of an expression equals the sum of the span
 of its components. Returns a vector of failing expressions.
 """
-function check_span(x::EXPR{StringH}, neq = []) end
-function check_span(x::T, neq = []) where T <: Union{IDENTIFIER,LITERAL,OPERATOR,KEYWORD,PUNCTUATION} neq end
-
-function check_span(x::UnaryOpCall, neq = []) 
-    check_span(x.op)
-    check_span(x.arg)
-    if x.op.fullspan + x.arg.fullspan != x.fullspan
-        push!(neq, x)
-    end
-    neq
-end
-function check_span(x::UnarySyntaxOpCall, neq = []) 
-    check_span(x.arg1)
-    check_span(x.arg2)
-    if x.arg1.fullspan + x.arg2.fullspan != x.fullspan
-        push!(neq, x)
-    end
-    neq
-end
-
-function check_span(x::T, neq = []) where T <: Union{BinaryOpCall,BinarySyntaxOpCall}
-    check_span(x.arg1)
-    check_span(x.op)
-    check_span(x.arg2)
-    if x.arg1.fullspan + x.op.fullspan + x.arg2.fullspan != x.fullspan
-        push!(neq, x)
-    end
-    neq
-end
-
-function check_span(x::WhereOpCall, neq = [])
-    check_span(x.arg1)
-    check_span(x.op)
-    for a in x.args
-        check_span(a)
-    end
-    if x.arg1.fullspan + x.op.fullspan + sum(a.fullspan for a in x.args) != x.fullspan
-        push!(neq, x)
-    end
-    neq
-end
-
-function check_span(x::ConditionalOpCall, neq = [])
-    check_span(x.cond)
-    check_span(x.op1)
-    check_span(x.arg1)
-    check_span(x.op2)
-    check_span(x.arg2)
-    if x.cond.fullspan + x.op1.fullspan + x.arg1.fullspan + x.op2.fullspan + x.arg2.fullspan != x.fullspan
-        push!(neq, x)
-    end
-    neq
-end
-
-
 function check_span(x::EXPR, neq = [])
+    (ispunctuation(x) || isidentifier(x) || iskw(x) || isoperator(x) || isliteral(x) || x.typ == StringH) && return neq
+    
     s = 0
     for a in x.args
         check_span(a, neq)
@@ -590,61 +539,26 @@ function check_reformat()
     end
 end
 
-
 function trailing_ws_length(x)
     x.fullspan - x.span
 end
 
-
-
-
 Base.iterate(x::EXPR) = length(x) == 0 ? nothing : (x.args[1], 1)
 Base.iterate(x::EXPR, s) = s < length(x) ? (x.args[s + 1], s + 1) : nothing
-Base.length(x::EXPR) = length(x.args)
+Base.length(x::EXPR) = x.args isa Nothing ? 0 : length(x.args)
 
-Base.iterate(x::UnaryOpCall) = x.op, 1
-Base.iterate(x::UnaryOpCall, s) = s == 1 ? (x.arg, 2) : nothing
-Base.length(x::UnaryOpCall) = 2
-
-Base.iterate(x::UnarySyntaxOpCall) = x.arg1, 1
-Base.iterate(x::UnarySyntaxOpCall, s) = s == 1 ? (x.arg2, 2) : nothing
-Base.length(x::UnarySyntaxOpCall) = 2
-
-Base.iterate(x::BinarySyntaxOpCall) = x.arg1, 1
-Base.iterate(x::BinarySyntaxOpCall, s) = s > 2 ? nothing : (getfield(x, s + 1), s + 1)
-Base.length(x::BinarySyntaxOpCall) = 3
-
-Base.iterate(x::BinaryOpCall) = x.arg1, 1
-Base.iterate(x::BinaryOpCall, s) = s > 2 ? nothing : (getfield(x, s + 1), s + 1)
-Base.length(x::BinaryOpCall) = 3
-
-Base.iterate(x::WhereOpCall) = x.arg1, 1
-function Base.iterate(x::WhereOpCall, s) 
-    if s == 1
-        return x.op, 2
-    elseif s < length(x)
-        return x.args[s - 1] , s + 1
-    end
-end
-Base.length(x::WhereOpCall) = 2 + length(x.args)
-
-Base.iterate(x::ConditionalOpCall) = x.cond, 1
-Base.iterate(x::ConditionalOpCall, s) = s < length(x) ? (getfield(x, s + 1), s + 1) : nothing
-Base.length(x::ConditionalOpCall) = 5
-
-for t in (CSTParser.IDENTIFIER, CSTParser.OPERATOR, CSTParser.LITERAL, CSTParser.PUNCTUATION, CSTParser.KEYWORD)
-    Base.iterate(x::t) = nothing
-    Base.iterate(x::t, s) = nothing
-    Base.length(x::t) = 0
-    Base.isiterable(x::t) = false
-end
 
 @inline val(token::RawToken, ps::ParseState) = String(ps.l.io.data[token.startbyte+1:token.endbyte+1])
 
-str_value(x) = ""
-str_value(x::T) where T <: Union{IDENTIFIER,LITERAL} = x.val
-str_value(x::OPERATOR) = string(Expr(x))
-str_value(x::EXPR{MacroName}) = string(Expr(x))
+function str_value(x)
+    if isidentifier(x) || x.typ === LITERAL
+        return x.val
+    elseif x.typ === OPERATOR || x.typ === MacroName
+        return string(Expr(x))
+    else
+        return ""
+    end
+end
 
 _unescape_string(s::AbstractString) = sprint(_unescape_string, s, sizehint=lastindex(s))
 function _unescape_string(io, s::AbstractString)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -619,3 +619,13 @@ function _unescape_string(io, s::AbstractString)
 end
 
 
+function match_closer(ps::ParseState)
+    length(ps.closer.cc) == 0 && return false
+    kind = ps.nt.kind
+    lc = last(ps.closer.cc)
+    return (kind === Tokens.RPAREN && lc == :paren) ||
+           (kind === Tokens.RSQUARE && lc == :square) ||
+           (kind === Tokens.RBRACE && lc == :braces) ||
+           (kind === Tokens.END && (lc == :begin || lc == :if)) 
+
+end

--- a/test/bindings.jl
+++ b/test/bindings.jl
@@ -1,0 +1,73 @@
+using CSTParser
+
+function collect_bindings(x, out = String[])
+    if x.binding != nothing
+        push!(out, x.binding.name)
+    end
+    if (x.typ === CSTParser.BinaryOpCall && CSTParser.is_assignment(x) && !CSTParser.is_func_call(x)) || x.typ === CSTParser.Filter
+        collect_bindings(x.args[3], out)
+        collect_bindings(x.args[2], out)
+        collect_bindings(x.args[1], out)
+    elseif x.typ === CSTParser.WhereOpCall
+        @inbounds for i = 3:length(x.args)
+            collect_bindings(x.args[i], out)
+        end
+        collect_bindings(x.args[1], out)
+        collect_bindings(x.args[2], out)
+    elseif x.typ === CSTParser.Generator
+        @inbounds for i = 2:length(x.args)
+            collect_bindings(x.args[i], out)
+        end
+        collect_bindings(x.args[1], out)
+    elseif x.args === nothing
+    else
+        @inbounds for a in x.args
+            collect_bindings(a, out)
+        end
+    end
+    return out
+end
+
+
+@test collect_bindings(CSTParser.parse("x = 1")) == ["x"]
+@test collect_bindings(CSTParser.parse("(x) = 1")) == ["x"]
+@test collect_bindings(CSTParser.parse("x, y =  1")) == ["x", "y"]
+@test collect_bindings(CSTParser.parse("(x, y) =  1")) == ["x", "y"]
+@test collect_bindings(CSTParser.parse("x = y =  1")) == ["y", "x"]
+@test collect_bindings(CSTParser.parse("x::T = 1")) == ["x"]
+
+@test collect_bindings(CSTParser.parse("f() = x")) == ["f"]
+@test collect_bindings(CSTParser.parse("f(a) = x")) == ["f", "a"]
+@test collect_bindings(CSTParser.parse("f(a) = x")) == ["f", "a"]
+collect_bindings(CSTParser.parse("f(x::T) where {T <: S} where R = x")) == ["f", "R", "T","x"]
+@test collect_bindings(CSTParser.parse("function f end")) == ["f"]
+@test collect_bindings(CSTParser.parse("function f() end")) == ["f"]
+@test collect_bindings(CSTParser.parse("function f() where T end")) == ["f", "T"]
+
+@test collect_bindings(CSTParser.parse("macro m end")) == ["m"]
+@test collect_bindings(CSTParser.parse("macro m() end")) == ["m"]
+
+@test collect_bindings(CSTParser.parse("abstract type T end")) == ["T"]
+@test collect_bindings(CSTParser.parse("abstract type T <: S end")) == ["T"]
+@test collect_bindings(CSTParser.parse("abstract type T{S} end")) == ["T"]
+
+@test collect_bindings(CSTParser.parse("primitive type T 4 end")) == ["T"]
+@test collect_bindings(CSTParser.parse("primitive type T <: S 4 end")) == ["T"]
+@test collect_bindings(CSTParser.parse("primitive type T{S} 4 end")) == ["T"]
+
+@test collect_bindings(CSTParser.parse("struct T end")) == ["T"]
+@test collect_bindings(CSTParser.parse("struct T <: S end")) == ["T"]
+@test collect_bindings(CSTParser.parse("struct T{S} end")) == ["T" ,"S"]
+@test collect_bindings(CSTParser.parse("struct T\nx end")) == ["T", "x"]
+@test collect_bindings(CSTParser.parse("struct T\nT() = new()\n end")) == ["T", "T"]
+
+@test collect_bindings(CSTParser.parse("mutable struct T end")) == ["T"]
+
+@test collect_bindings(CSTParser.parse("for i = 1 end")) == ["i"]
+@test collect_bindings(CSTParser.parse("let i = 1 end")) == ["i"]
+@test collect_bindings(CSTParser.parse("[i for i = 1]")) == ["i"]
+@test collect_bindings(CSTParser.parse("[i for i in 1]")) == ["i"]
+@test collect_bindings(CSTParser.parse("try catch e end")) == ["e"]
+@test collect_bindings(CSTParser.parse("map() do x end")) == ["x"]
+
+@test collect_bindings(CSTParser.parse("(a,b)->x")) == ["a", "b"]

--- a/test/bindings.jl
+++ b/test/bindings.jl
@@ -71,3 +71,4 @@ collect_bindings(CSTParser.parse("f(x::T) where {T <: S} where R = x")) == ["f",
 @test collect_bindings(CSTParser.parse("map() do x end")) == ["x"]
 
 @test collect_bindings(CSTParser.parse("(a,b)->x")) == ["a", "b"]
+collect_bindings(CSTParser.parse("function f(a::T = 1) end")) == ["f", "a"]

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -19,7 +19,7 @@ end
     @test CSTParser.defines_struct(CSTParser.parse("mutable struct T end"))
     @test CSTParser.defines_mutable(CSTParser.parse("mutable struct T end"))
     @test CSTParser.defines_abstract(CSTParser.parse("abstract type T end"))
-    @test CSTParser.defines_abstract(CSTParser.parse("abstract T"))
+    # @test CSTParser.defines_abstract(CSTParser.parse("abstract T"))
     @test CSTParser.defines_primitive(CSTParser.parse("primitive type a b end"))
 end
 

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -39,10 +39,10 @@ end
     @test CSTParser.get_name(CSTParser.parse("abstract type T <: T end")).val == "T"
     @test CSTParser.get_name(CSTParser.parse("abstract type T{T} <: T end")).val == "T"
     # NEEDS FIX: v0.6 dep
-    @test CSTParser.get_name(CSTParser.parse("abstract T")).val == "T"
-    @test CSTParser.get_name(CSTParser.parse("abstract T{T}")).val == "T"
-    @test CSTParser.get_name(CSTParser.parse("abstract T <: T")).val == "T"
-    @test CSTParser.get_name(CSTParser.parse("abstract T{T} <: T")).val == "T"
+    # @test CSTParser.get_name(CSTParser.parse("abstract T")).val == "T"
+    # @test CSTParser.get_name(CSTParser.parse("abstract T{T}")).val == "T"
+    # @test CSTParser.get_name(CSTParser.parse("abstract T <: T")).val == "T"
+    # @test CSTParser.get_name(CSTParser.parse("abstract T{T} <: T")).val == "T"
 
     @test CSTParser.get_name(CSTParser.parse("function f end")).val == "f"
     @test CSTParser.get_name(CSTParser.parse("function f() end")).val == "f"

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -762,6 +762,8 @@ end
     @test CSTParser.parse(": a")[1].typ === CSTParser.ErrorToken
     @test CSTParser.parse("const a")[2].typ === CSTParser.ErrorToken
     @test CSTParser.parse("const a = 1")[2].typ === CSTParser.BinaryOpCall
+    @test CSTParser.parse("const global a")[2].typ === CSTParser.ErrorToken
+    @test CSTParser.parse("const global a = 1")[2].typ === CSTParser.Global
 end
 
 end

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -567,7 +567,7 @@ end
     @test "isa(a,a) != isa(a,a)" |> test_expr
     @test "@mac return x" |> test_expr
     @static if VERSION > v"1.1-"
-        @test CSTParser.parse("a,b,").typ === CSTParser.ErrorToken
+        @test CSTParser.parse("a,b,").args[4].typ === CSTParser.ErrorToken
     else
         @test "a,b," |> test_expr
     end

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -193,7 +193,7 @@ end
 
 @testset "Tuples" begin
     @static if VERSION > v"1.1-"
-        @test CSTParser.parse("1,") isa CSTParser.EXPR{CSTParser.ErrorToken}
+        @test CSTParser.parse("1,").typ === CSTParser.ErrorToken
     else
         @test "1," |> test_expr
     end
@@ -567,7 +567,7 @@ end
     @test "isa(a,a) != isa(a,a)" |> test_expr
     @test "@mac return x" |> test_expr
     @static if VERSION > v"1.1-"
-        @test CSTParser.parse("a,b,") isa CSTParser.EXPR{CSTParser.ErrorToken}
+        @test CSTParser.parse("a,b,").typ === CSTParser.ErrorToken
     else
         @test "a,b," |> test_expr
     end

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -46,12 +46,10 @@ end
     #     end
     # end
     @testset "Conditional Operator" begin
-        strs = ["a ? b : c"
-                "a ? b : c : d"
-                "a ? b : c : d :e"]
-        for str in strs
-            @test test_expr(str)
-        end
+        @test test_expr("a ? b : c")
+        @test test_expr("a ? b : c : d")
+        @test test_expr("a ? b : c : d : e")
+        @test test_expr("a ? b : c : d : e")
     end
 
 
@@ -751,6 +749,19 @@ end
 
 @testset "conversion of floats with underscore" begin
     @test "30.424_876_125_859_513" |> test_expr
+end
+
+@testset "errors" begin
+    @test CSTParser.parse("1? b : c ")[1].typ === CSTParser.ErrorToken
+    @test CSTParser.parse("1 ?b : c ")[2].typ === CSTParser.ErrorToken
+    @test CSTParser.parse("1 ? b :c ")[4].typ === CSTParser.ErrorToken
+    @test CSTParser.parse("1:\n2")[2].typ === CSTParser.ErrorToken
+    @test CSTParser.parse("1.a")[1].typ === CSTParser.ErrorToken
+    @test CSTParser.parse("f ()").typ === CSTParser.ErrorToken
+    @test CSTParser.parse("f{t} ()").typ === CSTParser.ErrorToken
+    @test CSTParser.parse(": a")[1].typ === CSTParser.ErrorToken
+    @test CSTParser.parse("const a")[2].typ === CSTParser.ErrorToken
+    @test CSTParser.parse("const a = 1")[2].typ === CSTParser.BinaryOpCall
 end
 
 end

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -102,7 +102,7 @@ end
         @test "!(a,b)" |> test_expr
         @test "¬(a,b)" |> test_expr
         @test "~(a,b)" |> test_expr
-        @test_broken "<:(a,b)" |> test_expr_broken
+        @test "<:(a,b)" |> test_expr
         @test "√(a,b)" |> test_expr
         @test "\$(a,b)" |> test_expr
         @test ":(a,b)" |> test_expr
@@ -353,7 +353,7 @@ end
     @test "(arg for x in X if A for y in Y for z in Z)" |> test_expr
     @test "(arg for x in X if A for y in Y if B for z in Z)" |> test_expr
     @test "(arg for x in X if A for y in Y if B for z in Z if C)" |> test_expr
-    @test_broken "(arg for x in X, y in Y for z in Z)" |> test_expr_broken
+    @test "(arg for x in X, y in Y for z in Z)" |> test_expr
     @test "(arg for x in X, y in Y if A for z in Z)" |> test_expr
 end
 
@@ -697,8 +697,8 @@ end
     m = first(methods(f))
     @test DSE.keywords(f, m) == [:a, :b]
 end""" |> test_expr
-    @test "-1^a" |> test_expr_broken
-    @test "function(f, args...; kw...) end" |> test_expr_broken
+    @test "-1^a" |> test_expr
+    @test "function(f, args...; kw...) end" |> test_expr
     @test "2a * b" |> test_expr
     @test "(g1090(x::T)::T) where {T} = x+1.0" |> test_expr
     @test "(:) = Colon()" |> test_expr


### PR DESCRIPTION
Significant changes.
### Everything is an `EXPR`
I've dropped special expression types, including `LeafNode`s (`IDENTIFIER`, `OPERATOR`, etc). A new `.typ` field holds a `Head::Enum`, see `spec.jl` for details. The `.val` field contains the string representation of a token, where appropriate (e.g. for literals, identifiers). `.kind` holds the kind of a leaf EXPR, where appropriate (e.g. operators, literals).

We now store the parent of an expression in the `.parent` field.

### Simplification
Some `Head` types have been removed, notably the `xSyntaxOpCall`s. 

### Scopes and bindings
3 new fields have been added to `EXPR`: `scope`, `binding`, and `ref`. The first two are filed when an expression introduces a new scope or binding (e.g. `module A end` or `x = 1`).
Why? I'm working towards adding the ability to re-parse CST given changes to the underlying source (i.e. only updating modified expressions as necessary). This should (may?) allow for a more persistent approach in `StaticLint`.

Also some tidying up and fixing of known issues: incorrect `Flatten` conversion.
The refactoring of `EXPR` allows for a (minor) speed up despite us now doing the first stages of a semantic pass.

