### PR TITLE
Use semver for compat bounds

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ version = "0.6.0"
 Tokenize = "0796e94c-ce3b-5d07-9a54-7f471281c624"
 
 [compat]
-Tokenize = "0.5.3"
+Tokenize = "0.5.4"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -7,8 +7,8 @@ version = "0.6.0"
 Tokenize = "0796e94c-ce3b-5d07-9a54-7f471281c624"
 
 [compat]
-Tokenize = "≥ 0.5.3"
-julia = "≥ 1.0.0"
+Tokenize = "0.5.3"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
I think this is generally better practice.

For Julia, the new bound says that we are compatible with any 1.x.y. version. For Tokenize it says we are compatible with any 0.5.x version. So the assumption there is that minor versions are breaking (because the package is pre 1.0.0). I assume @KristofferC is following those guidelines in increasing version numbers? It would probably make sense to bump Tokenize to 1.0.0 whenever there is another breaking change.